### PR TITLE
Add Quadro T1000 Mobile to pci.ids

### DIFF
--- a/utils/pci.ids
+++ b/utils/pci.ids
@@ -2901,6 +2901,7 @@
 	1f92  TU117M [GeForce GTX 1650 Mobile]
 	1fae  TU117GL
 	1fb8  TU117GLM [Quadro T2000 Mobile / Max-Q]
+	1fb9  TU117GLM [Quadro T1000 Mobile]
 	1fbf  TU117GL
 	2182  TU116 [GeForce GTX 1660 Ti]
 	2183  TU116


### PR DESCRIPTION
I have this card and it was missing from pci.ids. lspci output below:
```
$ lspci -nnk -d 10de:
01:00.0 VGA compatible controller [0300]: NVIDIA Corporation TU117GLM [Quadro T1000 Mobile] [10de:1fb9] (rev a1)
	Subsystem: Lenovo Device [17aa:22b8]
	Kernel driver in use: vfio-pci
```