### PR TITLE
Create new list of devices for each vGPU type

### DIFF
--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -112,9 +112,9 @@ func createDevicePlugins() {
 			devicePlugins = append(devicePlugins, dp)
 		}
 	}
-	devs = nil
 	//Iterate over vGpuMap to create device plugin for each type of vGPU on the host
 	for k, v := range vGpuMap {
+		devs = nil
 		for _, dev := range v {
 			devs = append(devs, &pluginapi.Device{
 				ID:     dev.addr,


### PR DESCRIPTION
Signed-off-by: Christopher Desiniotis <cdesiniotis@nvidia.com>

This PR fixes a bug with creating vGPU device plugins. 

Without this change, we do not clear the list of vGPU devices across iterations over the `vGpuMap`. This results in incorrect accounting when reporting the number of vGPU devices of a particular type.

Below is an example on my system with 2x A10 GPUs. I have created three A10-8C vGPUs on the first GPU and two A10-12C vGPUs on the second GPU. Here is what gets reported to kubelet:
```
Capacity:
  cpu:                            80
  devices.kubevirt.io/kvm:        1k
  devices.kubevirt.io/sev:        1k
  devices.kubevirt.io/tun:        1k
  devices.kubevirt.io/vhost-net:  1k
  ephemeral-storage:              205375464Ki
  hugepages-1Gi:                  0
  hugepages-2Mi:                  0
  memory:                         394756664Ki
  nvidia.com/GA102GL_A10:         0
  nvidia.com/NVIDIA_A10-12C:      5
  nvidia.com/NVIDIA_A10-24C:      0
  nvidia.com/NVIDIA_A10-4C:       0
  nvidia.com/NVIDIA_A10-8C:       3
  nvidia.com/gpu:                 0
  pods:                           110
Allocatable:
  cpu:                            80
  devices.kubevirt.io/kvm:        1k
  devices.kubevirt.io/sev:        0
  devices.kubevirt.io/tun:        1k
  devices.kubevirt.io/vhost-net:  1k
  ephemeral-storage:              189274027310
  hugepages-1Gi:                  0
  hugepages-2Mi:                  0
  memory:                         394654264Ki
  nvidia.com/GA102GL_A10:         0
  nvidia.com/NVIDIA_A10-12C:      5
  nvidia.com/NVIDIA_A10-24C:      0
  nvidia.com/NVIDIA_A10-4C:       0
  nvidia.com/NVIDIA_A10-8C:       3
  nvidia.com/gpu:                 0
  pods:                           110
```
With the change from this PR, we get the correct accounting:
```
Capacity:
  cpu:                            80
  devices.kubevirt.io/kvm:        1k
  devices.kubevirt.io/sev:        1k
  devices.kubevirt.io/tun:        1k
  devices.kubevirt.io/vhost-net:  1k
  ephemeral-storage:              205375464Ki
  hugepages-1Gi:                  0
  hugepages-2Mi:                  0
  memory:                         394756664Ki
  nvidia.com/GA102GL_A10:         0
  nvidia.com/NVIDIA_A10-12C:      2
  nvidia.com/NVIDIA_A10-24C:      0
  nvidia.com/NVIDIA_A10-4C:       0
  nvidia.com/NVIDIA_A10-8C:       3
  nvidia.com/gpu:                 0
  pods:                           110
Allocatable:
  cpu:                            80
  devices.kubevirt.io/kvm:        1k
  devices.kubevirt.io/sev:        0
  devices.kubevirt.io/tun:        1k
  devices.kubevirt.io/vhost-net:  1k
  ephemeral-storage:              189274027310
  hugepages-1Gi:                  0
  hugepages-2Mi:                  0
  memory:                         394654264Ki
  nvidia.com/GA102GL_A10:         0
  nvidia.com/NVIDIA_A10-12C:      2
  nvidia.com/NVIDIA_A10-24C:      0
  nvidia.com/NVIDIA_A10-4C:       0
  nvidia.com/NVIDIA_A10-8C:       3
  nvidia.com/gpu:                 0
  pods:                           110
```
