### PR TITLE
fix: Matching error in getDeviceName

### DIFF
--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -314,6 +314,10 @@ func getDeviceName(deviceID string) string {
 				log.Printf("Error processing pci.ids file at line: %s", line)
 				return deviceName
 			}
+			// fix matching
+			if splits[0] != "" {
+				continue
+			}
 			deviceName = strings.TrimSpace(splits[1])
 			deviceName = strings.ToUpper(deviceName)
 			deviceName = strings.Replace(deviceName, "/", "_", -1)


### PR DESCRIPTION
fix deviceName split error for：
TU106_GEFORCE_RTX_2060_REV__A {deviceID: "1f08"}
TU116_GEFORCE_GTX_1660_SUPER {deviceID: "21c4"}
GA102_GEFORCE_RTX_3080 {deviceID: "2206"}