### PR TITLE
Start serving the plugin API prior to registering with kubelet

### DIFF
--- a/pkg/device_plugin/generic_device_plugin.go
+++ b/pkg/device_plugin/generic_device_plugin.go
@@ -139,18 +139,18 @@ func (dpi *GenericDevicePlugin) Start(stop chan struct{}) error {
 	dpi.server = grpc.NewServer([]grpc.ServerOption{}...)
 	pluginapi.RegisterDevicePluginServer(dpi.server, dpi)
 
-	err = dpi.Register()
-	if err != nil {
-		log.Printf("[%s] Error registering with device plugin manager: %v", dpi.deviceName, err)
-		return err
-	}
-
 	go dpi.server.Serve(sock)
 
 	err = waitForGrpcServer(dpi.socketPath, connectionTimeout)
 	if err != nil {
 		// this err is returned at the end of the Start function
 		log.Printf("[%s] Error connecting to GRPC server: %v", dpi.deviceName, err)
+	}
+
+	err = dpi.Register()
+	if err != nil {
+		log.Printf("[%s] Error registering with device plugin manager: %v", dpi.deviceName, err)
+		return err
 	}
 
 	go dpi.healthCheck()

--- a/pkg/device_plugin/generic_vgpu_device_plugin.go
+++ b/pkg/device_plugin/generic_vgpu_device_plugin.go
@@ -98,18 +98,18 @@ func (dpi *GenericVGpuDevicePlugin) Start(stop chan struct{}) error {
 	dpi.server = grpc.NewServer([]grpc.ServerOption{}...)
 	pluginapi.RegisterDevicePluginServer(dpi.server, dpi)
 
-	err = dpi.Register()
-	if err != nil {
-		log.Printf("[%s] Error registering with device plugin manager: %v", dpi.deviceName, err)
-		return err
-	}
-
 	go dpi.server.Serve(sock)
 
 	err = waitForGrpcServer(dpi.socketPath, connectionTimeout)
 	if err != nil {
 		// this err is returned at the end of the Start function
 		log.Printf("[%s] Error connecting to GRPC server: %v", dpi.deviceName, err)
+	}
+
+	err = dpi.Register()
+	if err != nil {
+		log.Printf("[%s] Error registering with device plugin manager: %v", dpi.deviceName, err)
+		return err
 	}
 
 	go dpi.healthCheck()


### PR DESCRIPTION
This is the recommended order when starting a plugin. Additionally, not starting the server prior to registration causes issues starting with K8s 1.25. It is unclear exactly what changed in 1.25 that brings this issue to surface, but it is possible kubelet now implicitly assumes a plugin is starting to serve the API upon receiving a registration request.

Without this change, we see the following kubelet logs:

```
"Got registration request from device plugin with resource" resourceName="nvidia.com/***" 
"Unable to connect to device plugin client with socket path" err="failed to dial device plugin: context deadline exceeded" path="/var/lib/kubelet/device-plugins/kubevirt-***.sock"
```

Signed-off-by: Christopher Desiniotis <cdesiniotis@nvidia.com>