### PR TITLE
fix: spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/crit…

### DIFF
--- a/manifests/nvidia-kubevirt-gpu-device-plugin.yaml
+++ b/manifests/nvidia-kubevirt-gpu-device-plugin.yaml
@@ -9,14 +9,10 @@ spec:
       name: nvidia-kubevirt-gpu-dp-ds
   template:
     metadata:
-      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
-      # reserves resources for critical add-on pods so that they can be rescheduled after
-      # a failure.  This annotation works in tandem with the toleration below.
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         name: nvidia-kubevirt-gpu-dp-ds
     spec:
+      priorityClassName: system-node-critical
       tolerations:
       # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
       # This, along with the annotation above marks this pod as a critical add-on.


### PR DESCRIPTION
fix: Warning: spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+; use the "priorityClassName" field instead
use "priorityClassName: system-node-critical"， "system-node-critical"  has the highest priority