### PR TITLE
Update README.md about grub2-mkconfig.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,17 @@ GRUB_TERMINAL_OUTPUT="console"
 GRUB_CMDLINE_LINUX="rd.lvm.lv=centos/root rd.lvm.lv=centos/swap rhgb quiet intel_iommu=on modprobe.blacklist=nouveau"
 GRUB_DISABLE_RECOVERY="true"
 ```
-```shell
+###### Legacy Mode
+```shell 
 grub2-mkconfig -o /boot/grub2/grub.cfg
 reboot
 ```
+###### UEFI Mode
+```shell 
+grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg # Centos 7.9
+reboot
+```
+
 After rebooting, verify IOMMU is enabled using following command
 ```shell
 dmesg | grep -E "DMAR|IOMMU"

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ GRUB_TERMINAL_OUTPUT="console"
 GRUB_CMDLINE_LINUX="rd.lvm.lv=centos/root rd.lvm.lv=centos/swap rhgb quiet intel_iommu=on modprobe.blacklist=nouveau"
 GRUB_DISABLE_RECOVERY="true"
 ```
-###### Legacy Mode
+###### Legacy Mode (BIOS)
 ```shell 
 grub2-mkconfig -o /boot/grub2/grub.cfg
 reboot
 ```
 ###### UEFI Mode
 ```shell 
-grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg # Centos 7.9
+grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg
 reboot
 ```
 


### PR DESCRIPTION
Added Grub2-mkconfig UEFI mode description, using Centos7.9 as an example.