### PR TITLE
Add numa node

### DIFF
--- a/pkg/device_plugin/generic_device_plugin_test.go
+++ b/pkg/device_plugin/generic_device_plugin_test.go
@@ -50,6 +50,7 @@ var pciAddress1 = "11"
 var pciAddress2 = "22"
 var pciAddress3 = "33"
 var nvVendorID = "10de"
+var numaNodeID = 0
 
 type fakeDevicePluginListAndWatchServer struct {
 	grpc.ServerStream


### PR DESCRIPTION
The PR adds tests to previously created by @silenceper PR https://github.com/NVIDIA/kubevirt-gpu-device-plugin/pull/76.

The main idea behind the improvement is to add NUMA node id of GPU card to `*pluginapi.Device`. This information can be used by TopologyManager of kubelet to allocate GPU devices along with other devices on the same NUMA node, such as a another GPU card or set or CPU.

More info about
- TopologyManager and TopologyHints https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/#how-topology-manager-works
- NUMA nodes https://enterprise-support.nvidia.com/s/article/understanding-numa-node-for-performance-benchmarks, https://research.nvidia.com/publication/2017-10_beyond-socket-numa-aware-gpus