### PR TITLE
Updating healthcheck for passthrough GPUs

### DIFF
--- a/manifests/nvidia-kubevirt-gpu-device-plugin.yaml
+++ b/manifests/nvidia-kubevirt-gpu-device-plugin.yaml
@@ -28,9 +28,14 @@ spec:
         volumeMounts:
           - name: device-plugin
             mountPath: /var/lib/kubelet/device-plugins
+          - name: vfio
+            mountPath: /dev/vfio
       imagePullSecrets:
       - name: regcred
       volumes:
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
+        - name: vfio
+          hostPath:
+            path: /dev/vfio

--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -107,7 +107,7 @@ func createDevicePlugins() {
 			deviceName = k
 		}
 		log.Printf("DP Name %s", deviceName)
-		dp := NewGenericDevicePlugin(deviceName, "/sys/kernel/iommu_groups/", devs)
+		dp := NewGenericDevicePlugin(deviceName, "/dev/vfio/", devs)
 		err := startDevicePlugin(dp)
 		if err != nil {
 			log.Printf("Error starting %s device plugin: %v", dp.deviceName, err)

--- a/pkg/device_plugin/generic_device_plugin.go
+++ b/pkg/device_plugin/generic_device_plugin.go
@@ -369,6 +369,7 @@ func (dpi *GenericDevicePlugin) healthCheck() error {
 	for _, dev := range dpi.devs {
 		devicePath := filepath.Join(path, dev.ID)
 		err = watcher.Add(devicePath)
+		log.Printf(" Adding Watcher to Path : %v", devicePath)
 		pathDeviceMap[devicePath] = dev.ID
 		if err != nil {
 			log.Printf("%s: Unable to add device path to fsnotify watcher: %v", method, err)


### PR DESCRIPTION
For a GPU configured as passthrough , device plugin does not update the GPU count on the node when a GPU falls off the bus.

To reproduce follow the steps

Remove the GPU from the bus
`echo "1" > /sys/bus/pci/devices/<gpu_pci_id>/remove`

Validated the GPU is no longer visible from the host using lspci
`lspci -nnk -d 10de:`

The number of GPUs exposed on k8s node doesn't change. 

Watching for iommu groups under `/dev/vfio` creates a fsnotify when the GPU falls off the bus

