### PR TITLE
Remove regcred from install manifest

### DIFF
--- a/manifests/nvidia-kubevirt-gpu-device-plugin.yaml
+++ b/manifests/nvidia-kubevirt-gpu-device-plugin.yaml
@@ -30,8 +30,6 @@ spec:
             mountPath: /var/lib/kubelet/device-plugins
           - name: vfio
             mountPath: /dev/vfio
-      imagePullSecrets:
-      - name: regcred
       volumes:
         - name: device-plugin
           hostPath:


### PR DESCRIPTION
Reg cred is in the default install manifest, however not needed as public image is being pulled