### PR TITLE
fix(allocate): swap busy vfio groups in Allocate() instead of hiding at discovery

### DIFF
--- a/.github/workflows/build-hive-image.yaml
+++ b/.github/workflows/build-hive-image.yaml
@@ -12,11 +12,6 @@ on:
           - dev
           - staging
           - production
-  push:
-    branches:
-      - master
-      - 'fix/**'
-      - 'feat/**'
 
 env:
   DOCKER_IMAGE: ${{ vars.DOCKER_REGISTRY }}/hive-compute-infra/kubevirt-gpu-device-plugin

--- a/.github/workflows/build-hive-image.yaml
+++ b/.github/workflows/build-hive-image.yaml
@@ -1,0 +1,68 @@
+name: Build Hive Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      env_name:
+        description: 'Target environment for image tag'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+  push:
+    branches:
+      - master
+      - 'fix/**'
+      - 'feat/**'
+
+env:
+  DOCKER_IMAGE: ${{ vars.DOCKER_REGISTRY }}/hive-compute-infra/kubevirt-gpu-device-plugin
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.env_name || 'dev' }}
+    name: Build kubevirt-gpu-device-plugin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get timestamp
+        run: echo "TIMESTAMP=$(date +"%Y%m%d%H%M%S")" >> $GITHUB_ENV
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          ENV_NAME="${{ github.event.inputs.env_name || 'dev' }}"
+          UPSTREAM_VERSION=$(awk -F'= ' '/^VERSION/ {print $2}' versions.mk | tr -d ' ')
+          SHORT_SHA="${GITHUB_SHA:0:8}"
+          IMAGE_TAG="${ENV_NAME}-${UPSTREAM_VERSION}-hive-${SHORT_SHA}-${TIMESTAMP}"
+          LATEST_TAG="${ENV_NAME}-latest"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+          echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_ENV
+          echo "Computed image tag: ${IMAGE_TAG}"
+
+      - name: Install Crane
+        uses: imjasonh/setup-crane@v0.5
+
+      - name: Login to OVH Registry
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login ${{ vars.DOCKER_REGISTRY }} -u "${{ vars.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build distroless image
+        run: |
+          make -C deployments/container build-distroless \
+            IMAGE_NAME="${DOCKER_IMAGE}" \
+            VERSION="${IMAGE_TAG}"
+
+      - name: Push image
+        run: |
+          docker push "${DOCKER_IMAGE}:${IMAGE_TAG}"
+          crane tag "${DOCKER_IMAGE}:${IMAGE_TAG}" "${LATEST_TAG}"
+          echo "Pushed ${DOCKER_IMAGE}:${IMAGE_TAG}"
+          echo "Tagged as ${DOCKER_IMAGE}:${LATEST_TAG}"

--- a/.github/workflows/build-hive-image.yaml
+++ b/.github/workflows/build-hive-image.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build distroless image
         run: |
-          make -C deployments/container build-distroless \
+          make -f deployments/container/Makefile build-distroless \
             IMAGE_NAME="${DOCKER_IMAGE}" \
             VERSION="${IMAGE_TAG}"
 

--- a/.github/workflows/build-hive-image.yaml
+++ b/.github/workflows/build-hive-image.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Login to OVH Registry
         run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login ${{ vars.DOCKER_REGISTRY }} -u "${{ vars.DOCKER_USERNAME }}" --password-stdin
+          echo '${{ secrets.DOCKER_PASSWORD }}' | docker login ${{ vars.DOCKER_REGISTRY }} -u '${{ vars.DOCKER_USERNAME }}' --password-stdin
 
       - name: Build distroless image
         run: |

--- a/.github/workflows/build-hive-image.yaml
+++ b/.github/workflows/build-hive-image.yaml
@@ -2,16 +2,6 @@ name: Build Hive Image
 
 on:
   workflow_dispatch:
-    inputs:
-      env_name:
-        description: 'Target environment for image tag'
-        required: true
-        default: 'dev'
-        type: choice
-        options:
-          - dev
-          - staging
-          - production
 
 env:
   DOCKER_IMAGE: ${{ vars.DOCKER_REGISTRY }}/hive-compute-infra/kubevirt-gpu-device-plugin
@@ -19,7 +9,10 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.env_name || 'dev' }}
+    # Single GitHub Environment holds the OVH registry credentials. The
+    # same image artefact is promoted across dev/staging/production via
+    # GitOps tag bumps, so no per-environment image variants exist.
+    environment: dev
     name: Build kubevirt-gpu-device-plugin
     steps:
       - name: Checkout
@@ -33,11 +26,13 @@ jobs:
       - name: Compute image tag
         id: tag
         run: |
-          ENV_NAME="${{ github.event.inputs.env_name || 'dev' }}"
           UPSTREAM_VERSION=$(awk -F'= ' '/^VERSION/ {print $2}' versions.mk | tr -d ' ')
           SHORT_SHA="${GITHUB_SHA:0:8}"
-          IMAGE_TAG="${ENV_NAME}-${UPSTREAM_VERSION}-hive-${SHORT_SHA}-${TIMESTAMP}"
-          LATEST_TAG="${ENV_NAME}-latest"
+          # Single canonical tag, promoted across environments unchanged.
+          # Shape: <upstream-version>-hive-<short-sha>-<timestamp>
+          # e.g.  v1.5.0-hive-15c40906-20260518163126
+          IMAGE_TAG="${UPSTREAM_VERSION}-hive-${SHORT_SHA}-${TIMESTAMP}"
+          LATEST_TAG="hive-latest"
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
           echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_ENV
           echo "Computed image tag: ${IMAGE_TAG}"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
+	golang.org/x/sys v0.40.0
 	google.golang.org/grpc v1.79.2
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubelet v0.33.5
@@ -24,7 +25,6 @@ require (
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -37,6 +37,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	klog "k8s.io/klog/v2"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -52,6 +53,11 @@ type NvidiaGpuDevice struct {
 	numaNode int64  // NUMA node ID
 }
 
+// mapsMu guards iommuMap, deviceMap, and bdfToIommuMap so that incremental
+// additions from the vfio-watcher (after the initial discovery walk) do not
+// race with reads from the device-plugin's Allocate() / health-check loops.
+var mapsMu sync.RWMutex
+
 // Key is iommu group id and value is a list of gpu devices part of the iommu group
 var iommuMap map[string][]NvidiaGpuDevice
 
@@ -60,6 +66,15 @@ var deviceMap map[string][]NvidiaGpuDevice
 
 // Maps PCI BDF to iommu group ids
 var bdfToIommuMap map[string]string
+
+// pluginRegistry maps a kubelet device-id (e.g. "2684" for an RTX 4090) to
+// the live GenericDevicePlugin advertising it, so the vfio-watcher can push
+// newly-bound GPUs into the right plugin's ListAndWatch stream without
+// restarting the process. Guarded by pluginRegistryMu.
+var (
+	pluginRegistryMu sync.Mutex
+	pluginRegistry   = map[string]*GenericDevicePlugin{}
+)
 
 // Key is vGPU Type and value is the list of Nvidia vGPUs of that type
 var vGpuMap map[string][]NvidiaGpuDevice
@@ -103,13 +118,23 @@ func createDevicePlugins() {
 	var devicePlugins []*GenericDevicePlugin
 	var vGpuDevicePlugins []*GenericVGpuDevicePlugin
 	var devs []*pluginapi.Device
+	// Snapshot deviceMap under the read lock so concurrent additions from
+	// the vfio-watcher do not race with this initial iteration.
+	mapsMu.RLock()
+	deviceMapSnapshot := make(map[string][]NvidiaGpuDevice, len(deviceMap))
+	for k, v := range deviceMap {
+		cp := make([]NvidiaGpuDevice, len(v))
+		copy(cp, v)
+		deviceMapSnapshot[k] = cp
+	}
 	log.Printf("Iommu Map %v", iommuMap)
 	log.Printf("Device Map %v", deviceMap)
+	mapsMu.RUnlock()
 	log.Println("vGPU Map ", vGpuMap)
 	log.Println("GPU vGPU Map ", gpuVgpuMap)
 
 	//Iterate over deivceMap to create device plugin for each type of GPU on the host
-	for k, gpuDevices := range deviceMap {
+	for k, gpuDevices := range deviceMapSnapshot {
 		devs = nil
 		for _, gpuDev := range gpuDevices {
 			device := &pluginapi.Device{
@@ -131,6 +156,9 @@ func createDevicePlugins() {
 		}
 		log.Printf("DP Name %s", deviceName)
 		dp := NewGenericDevicePlugin(deviceName, "/dev/vfio/", devs)
+		// Register before Start so the vfio-watcher callback can already
+		// reach this plugin if a late binding arrives during startup.
+		registerPlugin(k, dp)
 		err := startDevicePlugin(dp)
 		if err != nil {
 			log.Printf("Error starting %s device plugin: %v", dp.deviceName, err)
@@ -188,9 +216,11 @@ func startVgpuDevicePluginFunc(dp *GenericVGpuDevicePlugin) error {
 
 // Discovers all Nvidia GPUs which are loaded with VFIO-PCI driver and creates corresponding maps
 func createIommuDeviceMap() {
+	mapsMu.Lock()
 	iommuMap = make(map[string][]NvidiaGpuDevice)
 	deviceMap = make(map[string][]NvidiaGpuDevice)
 	bdfToIommuMap = make(map[string]string)
+	mapsMu.Unlock()
 	//Walk directory to discover pci devices
 	filepath.Walk(basePath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -201,51 +231,98 @@ func createIommuDeviceMap() {
 			log.Println("Not a device, continuing")
 			return nil
 		}
-		//Retrieve vendor for the device
-		vendorID, err := readIDFromFile(basePath, info.Name(), "vendor")
-		if err != nil {
-			log.Println("Could not get vendor ID for device ", info.Name())
-			return nil
-		}
-
-		//Nvidia vendor id is "10de". Proceed if vendor id is 10de
-		if vendorID == nvidiaVendorID {
-			log.Println("Nvidia device ", info.Name())
-			//Retrieve iommu group for the device
-			driver, err := readLink(basePath, info.Name(), "driver")
-			if err != nil {
-				log.Println("Could not get driver for device ", info.Name())
-				return nil
-			}
-			if !isSupportedVfioDriver(driver) {
-				log.Printf("Skipping %s: driver %s is not a supported VFIO driver", info.Name(), driver)
-				return nil
-			}
-			iommuGroup, err := readLink(basePath, info.Name(), "iommu_group")
-			if err != nil {
-				log.Println("Could not get IOMMU Group for device ", info.Name())
-				return nil
-			}
-			numaNode, err := readNUMANode(basePath, info.Name())
-			if err != nil {
-				log.Printf("Could not get NUMA node for device %s: %v. Defaulting to NUMA node 0", info.Name(), err)
-				numaNode = 0
-			}
-			log.Println("Iommu Group " + iommuGroup)
-			// Always record this PCI device (BDF) under its device ID so we
-			// advertise actual PCI BDFs to kubelet and provide NUMA topology.
-			deviceID, err := readIDFromFile(basePath, info.Name(), "device")
-			if err != nil {
-				log.Println("Could get deviceID for PCI address ", info.Name())
-				return nil
-			}
-			log.Printf("Device Id %s", deviceID)
-			deviceMap[deviceID] = append(deviceMap[deviceID], NvidiaGpuDevice{addr: info.Name(), numaNode: numaNode})
-			gpuDevice := NvidiaGpuDevice{addr: info.Name(), numaNode: numaNode}
-			iommuMap[iommuGroup] = append(iommuMap[iommuGroup], gpuDevice)
-			bdfToIommuMap[info.Name()] = iommuGroup
-		}
+		registerVfioBdf(info.Name())
 		return nil
+	})
+}
+
+// registerVfioBdf inspects a single PCI BDF in sysfs and, if it is an NVIDIA
+// GPU bound to a supported VFIO driver and not already known, adds it to
+// iommuMap / deviceMap / bdfToIommuMap. Returns the device id and the new
+// gpu-device entry along with whether anything was added.
+//
+// Used both during the initial walk and on every late vfio-pci binding the
+// watcher detects, so the in-memory pool grows incrementally without ever
+// restarting the plugin process — which is what previously caused the
+// kubelet device-manager accounting drift on multi-tenant GPU nodes.
+func registerVfioBdf(bdf string) (deviceID string, gpuDevice NvidiaGpuDevice, added bool) {
+	vendorID, err := readIDFromFile(basePath, bdf, "vendor")
+	if err != nil || vendorID != nvidiaVendorID {
+		return "", NvidiaGpuDevice{}, false
+	}
+	driver, err := readLink(basePath, bdf, "driver")
+	if err != nil {
+		log.Printf("registerVfioBdf %s: could not get driver: %v", bdf, err)
+		return "", NvidiaGpuDevice{}, false
+	}
+	if !isSupportedVfioDriver(driver) {
+		return "", NvidiaGpuDevice{}, false
+	}
+	iommuGroup, err := readLink(basePath, bdf, "iommu_group")
+	if err != nil {
+		log.Printf("registerVfioBdf %s: could not get iommu_group: %v", bdf, err)
+		return "", NvidiaGpuDevice{}, false
+	}
+	numaNode, err := readNUMANode(basePath, bdf)
+	if err != nil {
+		log.Printf("registerVfioBdf %s: could not get NUMA node: %v. Defaulting to 0", bdf, err)
+		numaNode = 0
+	}
+	deviceID, err = readIDFromFile(basePath, bdf, "device")
+	if err != nil {
+		log.Printf("registerVfioBdf %s: could not get deviceID: %v", bdf, err)
+		return "", NvidiaGpuDevice{}, false
+	}
+	gpuDevice = NvidiaGpuDevice{addr: bdf, numaNode: numaNode}
+
+	mapsMu.Lock()
+	if _, exists := bdfToIommuMap[bdf]; exists {
+		mapsMu.Unlock()
+		return deviceID, gpuDevice, false
+	}
+	deviceMap[deviceID] = append(deviceMap[deviceID], gpuDevice)
+	iommuMap[iommuGroup] = append(iommuMap[iommuGroup], gpuDevice)
+	bdfToIommuMap[bdf] = iommuGroup
+	mapsMu.Unlock()
+
+	log.Printf("registerVfioBdf %s: added (device=%s, iommu_group=%s, numa=%d)", bdf, deviceID, iommuGroup, numaNode)
+	return deviceID, gpuDevice, true
+}
+
+// registerPlugin associates a deviceID with the live GenericDevicePlugin
+// advertising it, so onLateVfioBinding can push new BDFs into the right
+// plugin's ListAndWatch stream.
+func registerPlugin(deviceID string, dp *GenericDevicePlugin) {
+	pluginRegistryMu.Lock()
+	defer pluginRegistryMu.Unlock()
+	pluginRegistry[deviceID] = dp
+}
+
+// onLateVfioBinding is the watcher callback. It registers the BDF in the
+// shared maps and, if a plugin for this device id is already running, pushes
+// the new device into its ListAndWatch stream so kubelet sees it without any
+// process restart. For a never-before-seen device id (e.g. a freshly-hot-
+// plugged GPU model that no other GPU on the node matches), the device is
+// recorded in the maps and will be advertised the next time the daemonset
+// restarts for an unrelated reason.
+func onLateVfioBinding(bdf string) {
+	deviceID, gpuDev, added := registerVfioBdf(bdf)
+	if !added {
+		return
+	}
+	pluginRegistryMu.Lock()
+	dp, ok := pluginRegistry[deviceID]
+	pluginRegistryMu.Unlock()
+	if !ok {
+		log.Printf("onLateVfioBinding: no live plugin for device id %s yet; new GPU %s will appear after next daemon restart", deviceID, bdf)
+		return
+	}
+	dp.AddDevice(&pluginapi.Device{
+		ID:     gpuDev.addr,
+		Health: pluginapi.Healthy,
+		Topology: &pluginapi.TopologyInfo{
+			Nodes: []*pluginapi.NUMANode{{ID: gpuDev.numaNode}},
+		},
 	})
 }
 
@@ -359,12 +436,31 @@ func readGpuIDForVgpuFunc(basePath string, deviceAddress string) (string, error)
 
 }
 
+// getIommuMap returns a snapshot copy of iommuMap taken under the maps
+// read lock, so callers can iterate without racing concurrent additions
+// from the vfio-watcher's onLateVfioBinding path.
 func getIommuMap() map[string][]NvidiaGpuDevice {
-	return iommuMap
+	mapsMu.RLock()
+	defer mapsMu.RUnlock()
+	out := make(map[string][]NvidiaGpuDevice, len(iommuMap))
+	for k, v := range iommuMap {
+		cp := make([]NvidiaGpuDevice, len(v))
+		copy(cp, v)
+		out[k] = cp
+	}
+	return out
 }
 
+// getBdfToIommuMap returns a snapshot copy of bdfToIommuMap taken under
+// the maps read lock.
 func getBdfToIommuMap() map[string]string {
-	return bdfToIommuMap
+	mapsMu.RLock()
+	defer mapsMu.RUnlock()
+	out := make(map[string]string, len(bdfToIommuMap))
+	for k, v := range bdfToIommuMap {
+		out[k] = v
+	}
+	return out
 }
 
 func getGpuVgpuMap() map[string][]string {

--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -226,6 +226,17 @@ func createIommuDeviceMap() {
 				log.Println("Could not get IOMMU Group for device ", info.Name())
 				return nil
 			}
+			// Skip devices whose /dev/vfio/<group> is already held by
+			// another process — typically a running tenant VM that has
+			// this GPU passed through. Advertising them as free causes
+			// kubelet to hand the PCI ID to a new pod, whose qemu then
+			// fails with "Could not open '/dev/vfio/<group>': Device or
+			// resource busy". They are re-evaluated by healthCheck and
+			// re-added once the holder releases the group.
+			if isVfioGroupBusy(iommuGroup) {
+				log.Printf("Skipping %s: /dev/vfio/%s is held by another process (already in use)", info.Name(), iommuGroup)
+				return nil
+			}
 			numaNode, err := readNUMANode(basePath, info.Name())
 			if err != nil {
 				log.Printf("Could not get NUMA node for device %s: %v. Defaulting to NUMA node 0", info.Name(), err)

--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -91,6 +91,9 @@ func InitiateDevicePlugin() {
 	createIommuDeviceMap()
 	//Identifies vGPUs and represents it in appropriate structures
 	createVgpuIDMap()
+	//Watch for NVIDIA GPUs bound to a VFIO driver after initial discovery,
+	//and trigger a process exit so the daemonset re-runs discovery on restart.
+	go watchVfioBindings(stop)
 	//Creates and starts device plugin
 	createDevicePlugins()
 }

--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -112,9 +112,21 @@ func createDevicePlugins() {
 	for k, gpuDevices := range deviceMap {
 		devs = nil
 		for _, gpuDev := range gpuDevices {
+			// Mark devices whose /dev/vfio/<group> is currently held by
+			// another process as Unhealthy. Including them in the pool
+			// preserves the kubelet's capacity accounting and the existing
+			// allocations of running pods that already hold them; the
+			// Unhealthy flag keeps the kubelet from handing the same PCI
+			// ID to a new pod, which would otherwise fail with
+			// "Could not open '/dev/vfio/<group>': Device or resource busy".
+			health := pluginapi.Healthy
+			if iommuGroup, ok := bdfToIommuMap[gpuDev.addr]; ok && isVfioGroupBusy(iommuGroup) {
+				health = pluginapi.Unhealthy
+				log.Printf("Marking %s Unhealthy: /dev/vfio/%s is held by another process (already in use)", gpuDev.addr, iommuGroup)
+			}
 			device := &pluginapi.Device{
 				ID:     gpuDev.addr,
-				Health: pluginapi.Healthy,
+				Health: health,
 				Topology: &pluginapi.TopologyInfo{
 					Nodes: []*pluginapi.NUMANode{
 						{ID: gpuDev.numaNode},
@@ -224,17 +236,6 @@ func createIommuDeviceMap() {
 			iommuGroup, err := readLink(basePath, info.Name(), "iommu_group")
 			if err != nil {
 				log.Println("Could not get IOMMU Group for device ", info.Name())
-				return nil
-			}
-			// Skip devices whose /dev/vfio/<group> is already held by
-			// another process — typically a running tenant VM that has
-			// this GPU passed through. Advertising them as free causes
-			// kubelet to hand the PCI ID to a new pod, whose qemu then
-			// fails with "Could not open '/dev/vfio/<group>': Device or
-			// resource busy". They are re-evaluated by healthCheck and
-			// re-added once the holder releases the group.
-			if isVfioGroupBusy(iommuGroup) {
-				log.Printf("Skipping %s: /dev/vfio/%s is held by another process (already in use)", info.Name(), iommuGroup)
 				return nil
 			}
 			numaNode, err := readNUMANode(basePath, info.Name())

--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -137,21 +137,18 @@ func createDevicePlugins() {
 	for k, gpuDevices := range deviceMapSnapshot {
 		devs = nil
 		for _, gpuDev := range gpuDevices {
-			// Mark devices whose /dev/vfio/<group> is currently held by
-			// another process as Unhealthy. Including them in the pool
-			// preserves the kubelet's capacity accounting and the existing
-			// allocations of running pods that already hold them; the
-			// Unhealthy flag keeps the kubelet from handing the same PCI
-			// ID to a new pod, which would otherwise fail with
-			// "Could not open '/dev/vfio/<group>': Device or resource busy".
-			health := pluginapi.Healthy
-			if iommuGroup, ok := bdfToIommuMap[gpuDev.addr]; ok && isVfioGroupBusy(iommuGroup) {
-				health = pluginapi.Unhealthy
-				log.Printf("Marking %s Unhealthy: /dev/vfio/%s is held by another process (already in use)", gpuDev.addr, iommuGroup)
-			}
+			// Always advertise every GPU bound to vfio-pci as Healthy so the
+			// node's nvidia.com/<model> capacity reflects the physical
+			// hardware (e.g. 8 on an 8x card host). The platform-api computes
+			// "available" as `allocatable - sum(GPUs of running instances)`,
+			// so shrinking allocatable when devices are in passthrough causes
+			// a double-subtraction and the location reports negative free
+			// GPUs. The "currently in use" check is enforced in Allocate()
+			// and GetPreferredAllocation() instead, where it can swap a busy
+			// PCI ID for a free one without ever lying about capacity.
 			device := &pluginapi.Device{
 				ID:     gpuDev.addr,
-				Health: health,
+				Health: pluginapi.Healthy,
 				Topology: &pluginapi.TopologyInfo{
 					Nodes: []*pluginapi.NUMANode{
 						{ID: gpuDev.numaNode},

--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -102,14 +102,14 @@ var startVgpuDevicePlugin = startVgpuDevicePluginFunc
 var stop = make(chan struct{})
 
 func InitiateDevicePlugin() {
-	//Identifies GPUs and represents it in appropriate structures
+	// Initial sysfs discovery of every NVIDIA GPU already bound to a
+	// supported VFIO driver.
 	createIommuDeviceMap()
-	//Identifies vGPUs and represents it in appropriate structures
 	createVgpuIDMap()
-	//Watch for NVIDIA GPUs bound to a VFIO driver after initial discovery,
-	//and trigger a process exit so the daemonset re-runs discovery on restart.
-	go watchVfioBindings(stop)
-	//Creates and starts device plugin
+	// Stream subsequent vfio-pci bindings into the live ListAndWatch frame
+	// of the matching GenericDevicePlugin so kubelet sees the new device
+	// without us exiting the process.
+	go watchVfioBindings(stop, onLateVfioBinding)
 	createDevicePlugins()
 }
 
@@ -236,92 +236,124 @@ func createIommuDeviceMap() {
 	})
 }
 
-// registerVfioBdf inspects a single PCI BDF in sysfs and, if it is an NVIDIA
-// GPU bound to a supported VFIO driver and not already known, adds it to
-// iommuMap / deviceMap / bdfToIommuMap. Returns the device id and the new
-// gpu-device entry along with whether anything was added.
-//
-// Used both during the initial walk and on every late vfio-pci binding the
-// watcher detects, so the in-memory pool grows incrementally without ever
-// restarting the plugin process — which is what previously caused the
-// kubelet device-manager accounting drift on multi-tenant GPU nodes.
-func registerVfioBdf(bdf string) (deviceID string, gpuDevice NvidiaGpuDevice, added bool) {
+// vfioDeviceInfo is the resolved sysfs view of a single NVIDIA PCI device
+// bound to a supported VFIO driver, used to bridge the pure inspection step
+// (inspectVfioPciDevice) and the map mutation step (recordVfioDevice).
+type vfioDeviceInfo struct {
+	bdf        string
+	deviceID   string
+	iommuGroup string
+	gpu        NvidiaGpuDevice
+}
+
+// inspectVfioPciDevice reads the sysfs entries for a single PCI BDF and
+// returns the resolved vfioDeviceInfo, or (nil, false) if the device is not
+// an NVIDIA GPU bound to a supported VFIO driver. Pure read; no map mutation.
+func inspectVfioPciDevice(bdf string) (*vfioDeviceInfo, bool) {
 	vendorID, err := readIDFromFile(basePath, bdf, "vendor")
 	if err != nil || vendorID != nvidiaVendorID {
-		return "", NvidiaGpuDevice{}, false
+		return nil, false
 	}
 	driver, err := readLink(basePath, bdf, "driver")
 	if err != nil {
-		log.Printf("registerVfioBdf %s: could not get driver: %v", bdf, err)
-		return "", NvidiaGpuDevice{}, false
+		log.Printf("inspectVfioPciDevice %s: read driver: %v", bdf, err)
+		return nil, false
 	}
 	if !isSupportedVfioDriver(driver) {
-		return "", NvidiaGpuDevice{}, false
+		return nil, false
 	}
 	iommuGroup, err := readLink(basePath, bdf, "iommu_group")
 	if err != nil {
-		log.Printf("registerVfioBdf %s: could not get iommu_group: %v", bdf, err)
-		return "", NvidiaGpuDevice{}, false
+		log.Printf("inspectVfioPciDevice %s: read iommu_group: %v", bdf, err)
+		return nil, false
+	}
+	deviceID, err := readIDFromFile(basePath, bdf, "device")
+	if err != nil {
+		log.Printf("inspectVfioPciDevice %s: read device id: %v", bdf, err)
+		return nil, false
 	}
 	numaNode, err := readNUMANode(basePath, bdf)
 	if err != nil {
-		log.Printf("registerVfioBdf %s: could not get NUMA node: %v. Defaulting to 0", bdf, err)
+		log.Printf("inspectVfioPciDevice %s: read NUMA node: %v — defaulting to 0", bdf, err)
 		numaNode = 0
 	}
-	deviceID, err = readIDFromFile(basePath, bdf, "device")
-	if err != nil {
-		log.Printf("registerVfioBdf %s: could not get deviceID: %v", bdf, err)
-		return "", NvidiaGpuDevice{}, false
-	}
-	gpuDevice = NvidiaGpuDevice{addr: bdf, numaNode: numaNode}
-
-	mapsMu.Lock()
-	if _, exists := bdfToIommuMap[bdf]; exists {
-		mapsMu.Unlock()
-		return deviceID, gpuDevice, false
-	}
-	deviceMap[deviceID] = append(deviceMap[deviceID], gpuDevice)
-	iommuMap[iommuGroup] = append(iommuMap[iommuGroup], gpuDevice)
-	bdfToIommuMap[bdf] = iommuGroup
-	mapsMu.Unlock()
-
-	log.Printf("registerVfioBdf %s: added (device=%s, iommu_group=%s, numa=%d)", bdf, deviceID, iommuGroup, numaNode)
-	return deviceID, gpuDevice, true
+	return &vfioDeviceInfo{
+		bdf:        bdf,
+		deviceID:   deviceID,
+		iommuGroup: iommuGroup,
+		gpu:        NvidiaGpuDevice{addr: bdf, numaNode: numaNode},
+	}, true
 }
 
-// registerPlugin associates a deviceID with the live GenericDevicePlugin
-// advertising it, so onLateVfioBinding can push new BDFs into the right
-// plugin's ListAndWatch stream.
+// recordVfioDevice atomically adds info to iommuMap / deviceMap / bdfToIommuMap
+// under mapsMu. Returns false if the BDF was already known (so duplicate
+// late-binding events are idempotent).
+func recordVfioDevice(info *vfioDeviceInfo) bool {
+	mapsMu.Lock()
+	defer mapsMu.Unlock()
+	if _, exists := bdfToIommuMap[info.bdf]; exists {
+		return false
+	}
+	deviceMap[info.deviceID] = append(deviceMap[info.deviceID], info.gpu)
+	iommuMap[info.iommuGroup] = append(iommuMap[info.iommuGroup], info.gpu)
+	bdfToIommuMap[info.bdf] = info.iommuGroup
+	return true
+}
+
+// registerVfioBdf is the discovery-time entry point used both by the
+// initial sysfs walk and by the late-binding watcher. It performs the
+// inspect-then-record pair and returns the resolved info so the caller
+// can decide what to do with it (e.g. push into a live ListAndWatch frame).
+// Returns (nil, false) if the BDF is not an NVIDIA VFIO GPU or is already
+// known.
+func registerVfioBdf(bdf string) (*vfioDeviceInfo, bool) {
+	info, ok := inspectVfioPciDevice(bdf)
+	if !ok {
+		return nil, false
+	}
+	if !recordVfioDevice(info) {
+		return nil, false
+	}
+	log.Printf("registerVfioBdf %s: added (device=%s, iommu_group=%s, numa=%d)", info.bdf, info.deviceID, info.iommuGroup, info.gpu.numaNode)
+	return info, true
+}
+
+// registerPlugin associates a kubelet device id (e.g. "2684" for an RTX
+// 4090) with the live GenericDevicePlugin advertising it, so
+// onLateVfioBinding can push newly-bound BDFs into the right plugin's
+// ListAndWatch stream.
 func registerPlugin(deviceID string, dp *GenericDevicePlugin) {
 	pluginRegistryMu.Lock()
 	defer pluginRegistryMu.Unlock()
 	pluginRegistry[deviceID] = dp
 }
 
-// onLateVfioBinding is the watcher callback. It registers the BDF in the
-// shared maps and, if a plugin for this device id is already running, pushes
-// the new device into its ListAndWatch stream so kubelet sees it without any
-// process restart. For a never-before-seen device id (e.g. a freshly-hot-
-// plugged GPU model that no other GPU on the node matches), the device is
-// recorded in the maps and will be advertised the next time the daemonset
-// restarts for an unrelated reason.
+// onLateVfioBinding is invoked by watchVfioBindings for each new NVIDIA
+// GPU bound to a VFIO driver after the initial discovery. It records the
+// device and, if a plugin for this device id is already running, pushes
+// the new device into its ListAndWatch stream.
+//
+// If no plugin exists yet for this device id — e.g. the first GPU of a
+// previously-absent model is hot-plugged — the device is still recorded
+// so it will be picked up on the next daemonset restart, but no live
+// update can be sent until createDevicePlugins is re-run.
 func onLateVfioBinding(bdf string) {
-	deviceID, gpuDev, added := registerVfioBdf(bdf)
-	if !added {
+	info, ok := registerVfioBdf(bdf)
+	if !ok {
 		return
 	}
 	pluginRegistryMu.Lock()
-	dp, ok := pluginRegistry[deviceID]
+	dp, hasPlugin := pluginRegistry[info.deviceID]
 	pluginRegistryMu.Unlock()
-	if !ok {
-		log.Printf("onLateVfioBinding: no live plugin for device id %s yet; new GPU %s will appear after next daemon restart", deviceID, bdf)
+	if !hasPlugin {
+		log.Printf("onLateVfioBinding %s: no live plugin for device id %s yet — will be advertised on next daemon restart", bdf, info.deviceID)
 		return
 	}
 	dp.AddDevice(&pluginapi.Device{
-		ID:     gpuDev.addr,
+		ID:     info.gpu.addr,
 		Health: pluginapi.Healthy,
 		Topology: &pluginapi.TopologyInfo{
-			Nodes: []*pluginapi.NUMANode{{ID: gpuDev.numaNode}},
+			Nodes: []*pluginapi.NUMANode{{ID: info.gpu.numaNode}},
 		},
 	})
 }

--- a/pkg/device_plugin/generic_device_plugin.go
+++ b/pkg/device_plugin/generic_device_plugin.go
@@ -40,6 +40,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -71,6 +72,8 @@ var discoverEGMDevices = discoverEGMDevicesFunc
 // Implements the kubernetes device plugin API
 type GenericDevicePlugin struct {
 	devs       []*pluginapi.Device
+	devsMu     sync.RWMutex // guards devs against concurrent AddDevice + ListAndWatch + health updates
+	update     chan struct{}
 	server     *grpc.Server
 	socketPath string
 	stop       chan struct{} // this channel signals to stop the DP
@@ -87,6 +90,7 @@ func NewGenericDevicePlugin(deviceName string, devicePath string, devices []*plu
 	serverSock := fmt.Sprintf(pluginapi.DevicePluginPath+"kubevirt-%s.sock", deviceName)
 	dpi := &GenericDevicePlugin{
 		devs:       devices,
+		update:     make(chan struct{}, 1),
 		socketPath: serverSock,
 		term:       make(chan bool, 1),
 		healthy:    make(chan string),
@@ -95,6 +99,39 @@ func NewGenericDevicePlugin(deviceName string, devicePath string, devices []*plu
 		devicePath: devicePath,
 	}
 	return dpi
+}
+
+// AddDevice appends a newly-bound NVIDIA GPU to the plugin's advertised pool
+// and signals ListAndWatch to send an updated frame to kubelet. Safe to call
+// from any goroutine. A second call for the same device ID is a no-op so the
+// vfio-watcher can re-emit a BDF without growing the pool.
+func (dpi *GenericDevicePlugin) AddDevice(dev *pluginapi.Device) {
+	dpi.devsMu.Lock()
+	for _, existing := range dpi.devs {
+		if existing.ID == dev.ID {
+			dpi.devsMu.Unlock()
+			return
+		}
+	}
+	dpi.devs = append(dpi.devs, dev)
+	dpi.devsMu.Unlock()
+
+	// Non-blocking: ListAndWatch will see the new dev on its next iteration
+	// even if the channel already has a pending signal.
+	select {
+	case dpi.update <- struct{}{}:
+	default:
+	}
+}
+
+// snapshotDevs returns a copy of devs taken under the read lock so callers
+// can iterate without holding the mutex while talking to kubelet.
+func (dpi *GenericDevicePlugin) snapshotDevs() []*pluginapi.Device {
+	dpi.devsMu.RLock()
+	defer dpi.devsMu.RUnlock()
+	out := make([]*pluginapi.Device, len(dpi.devs))
+	copy(out, dpi.devs)
+	return out
 }
 
 func buildEnv(envList map[string][]string) map[string]string {
@@ -311,8 +348,9 @@ func (dpi *GenericDevicePlugin) Register() error {
 // ListAndWatch lists devices and update that list according to the health status
 func (dpi *GenericDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
 
-	log.Printf("[%s] ListAndWatch called, sending %d devices:", dpi.deviceName, len(dpi.devs))
-	for _, dev := range dpi.devs {
+	initialDevs := dpi.snapshotDevs()
+	log.Printf("[%s] ListAndWatch called, sending %d devices:", dpi.deviceName, len(initialDevs))
+	for _, dev := range initialDevs {
 		numaNodes := "nil"
 		if dev.Topology != nil && len(dev.Topology.Nodes) > 0 {
 			numaNodes = fmt.Sprintf("%d", dev.Topology.Nodes[0].ID)
@@ -320,26 +358,35 @@ func (dpi *GenericDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.Dev
 		log.Printf("  Device ID=%s, Health=%s, NUMA=%s", dev.ID, dev.Health, numaNodes)
 	}
 
-	s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.devs})
+	s.Send(&pluginapi.ListAndWatchResponse{Devices: initialDevs})
 
 	for {
 		select {
 		case unhealthy := <-dpi.unhealthy:
 			log.Printf("In watch unhealthy")
+			dpi.devsMu.Lock()
 			for _, dev := range dpi.devs {
 				if unhealthy == dev.ID {
 					dev.Health = pluginapi.Unhealthy
 				}
 			}
-			s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.devs})
+			dpi.devsMu.Unlock()
+			s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.snapshotDevs()})
 		case healthy := <-dpi.healthy:
 			log.Printf("In watch healthy")
+			dpi.devsMu.Lock()
 			for _, dev := range dpi.devs {
 				if healthy == dev.ID {
 					dev.Health = pluginapi.Healthy
 				}
 			}
-			s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.devs})
+			dpi.devsMu.Unlock()
+			s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.snapshotDevs()})
+		case <-dpi.update:
+			// AddDevice signalled a new device joined the pool — re-publish.
+			snap := dpi.snapshotDevs()
+			log.Printf("[%s] device pool grew, sending %d devices to kubelet", dpi.deviceName, len(snap))
+			s.Send(&pluginapi.ListAndWatchResponse{Devices: snap})
 		case <-dpi.stop:
 			return nil
 		case <-dpi.term:
@@ -478,7 +525,7 @@ func (dpi *GenericDevicePlugin) GetPreferredAllocation(ctx context.Context, in *
 
 		// Build a map of device ID to NUMA node from our device list
 		deviceToNUMA := make(map[string]int64)
-		for _, dev := range dpi.devs {
+		for _, dev := range dpi.snapshotDevs() {
 			if dev.Topology != nil && len(dev.Topology.Nodes) > 0 {
 				deviceToNUMA[dev.ID] = dev.Topology.Nodes[0].ID
 			}
@@ -637,7 +684,7 @@ func (dpi *GenericDevicePlugin) healthCheck() error {
 	}
 
 	bdfToIommu := returnBdfToIommuMap()
-	for _, dev := range dpi.devs {
+	for _, dev := range dpi.snapshotDevs() {
 		iommuID, ok := bdfToIommu[dev.ID]
 		if !ok {
 			log.Printf("%s: Unable to determine IOMMU group for device %s", method, dev.ID)

--- a/pkg/device_plugin/generic_device_plugin.go
+++ b/pkg/device_plugin/generic_device_plugin.go
@@ -420,7 +420,24 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 		seenDeviceSpecs := make(map[string]struct{})
 		returnedMap := returnIommuMap()
 		bdfToIommu := returnBdfToIommuMap()
-		for _, bdf := range req.DevicesIDs {
+		// Substitute any requested PCI ID whose /dev/vfio/<group> is currently
+		// held by another process with a free device from the same pool. This
+		// covers the case where the plugin restarts while tenant VMs are
+		// passthrough'd and kubelet's checkpoint drifts: kubelet may then ask
+		// for a PCI ID that is actually in use, which would otherwise produce
+		// the "Could not open '/dev/vfio/<group>': Device or resource busy"
+		// qemu crashloop. The swap is silent from kubelet's perspective —
+		// the response carries DeviceSpecs for the substituted ID instead.
+		allocatedIDs := req.DevicesIDs
+		swapped, err := substituteBusyDevices(dpi.snapshotDevs(), allocatedIDs, bdfToIommu)
+		if err != nil {
+			return nil, fmt.Errorf("[%s] Allocate: %w", dpi.deviceName, err)
+		}
+		if !slices.Equal(swapped, allocatedIDs) {
+			log.Printf("[%s] Allocate: substituted busy devices %v -> %v", dpi.deviceName, allocatedIDs, swapped)
+			allocatedIDs = swapped
+		}
+		for _, bdf := range allocatedIDs {
 			iommuId, ok := bdfToIommu[bdf]
 			if !ok {
 				return nil, fmt.Errorf("invalid allocation request: unknown device: %s", bdf)
@@ -470,7 +487,7 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 			}
 			envList[key] = append(envList[key], devAddrs...)
 		}
-		egmPaths := egmPathsForAllocatedGPUs(req.DevicesIDs, egmDevices)
+		egmPaths := egmPathsForAllocatedGPUs(allocatedIDs, egmDevices)
 		for _, egmPath := range egmPaths {
 			appendDeviceSpec(&deviceSpecs, seenDeviceSpecs, egmPath)
 		}
@@ -519,9 +536,17 @@ func (dpi *GenericDevicePlugin) GetPreferredAllocation(ctx context.Context, in *
 
 	response := &pluginapi.PreferredAllocationResponse{}
 
+	bdfToIommu := returnBdfToIommuMap()
 	for idx, req := range in.ContainerRequests {
 		log.Printf("[%s] Container request %d: Available devices=%v, MustInclude=%v, AllocationSize=%d",
 			dpi.deviceName, idx, req.AvailableDeviceIDs, req.MustIncludeDeviceIDs, req.AllocationSize)
+
+		// Bias the available pool so currently-free vfio groups are picked
+		// first. Busy IDs stay in the pool (kubelet may still need them to
+		// satisfy MustInclude or to fill the allocation when no free
+		// substitute exists) but get the back of the queue so the NUMA
+		// pass below preferentially packs around the genuinely-free ones.
+		req.AvailableDeviceIDs = filterPreferredFreeDevices(req.AvailableDeviceIDs, bdfToIommu)
 
 		// Build a map of device ID to NUMA node from our device list
 		deviceToNUMA := make(map[string]int64)

--- a/pkg/device_plugin/incremental_test.go
+++ b/pkg/device_plugin/incremental_test.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package device_plugin
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+var _ = Describe("incremental late-binding discovery", func() {
+
+	Describe("GenericDevicePlugin.AddDevice", func() {
+		It("appends a new device and signals ListAndWatch via the update channel", func() {
+			dp := NewGenericDevicePlugin("test", "/dev/vfio/", []*pluginapi.Device{
+				{ID: "0000:01:00.0", Health: pluginapi.Healthy},
+			})
+
+			dp.AddDevice(&pluginapi.Device{ID: "0000:23:00.0", Health: pluginapi.Healthy})
+
+			Expect(dp.snapshotDevs()).To(HaveLen(2))
+			ids := make([]string, 0, 2)
+			for _, d := range dp.snapshotDevs() {
+				ids = append(ids, d.ID)
+			}
+			Expect(ids).To(ConsistOf("0000:01:00.0", "0000:23:00.0"))
+
+			select {
+			case <-dp.update:
+				// good
+			default:
+				Fail("AddDevice must signal ListAndWatch via the update channel")
+			}
+		})
+
+		It("is idempotent: re-adding the same device ID does not grow the pool", func() {
+			dp := NewGenericDevicePlugin("test", "/dev/vfio/", []*pluginapi.Device{
+				{ID: "0000:01:00.0", Health: pluginapi.Healthy},
+			})
+
+			dp.AddDevice(&pluginapi.Device{ID: "0000:01:00.0", Health: pluginapi.Healthy})
+
+			Expect(dp.snapshotDevs()).To(HaveLen(1),
+				"second AddDevice for the same ID must be a no-op so the watcher can safely re-emit a BDF")
+		})
+	})
+
+	Describe("onLateVfioBinding", func() {
+		var (
+			origReadLink     func(string, string, string) (string, error)
+			origReadID       func(string, string, string) (string, error)
+			origReadNUMA     func(string, string) (int64, error)
+			origDeviceMap    map[string][]NvidiaGpuDevice
+			origIommuMap     map[string][]NvidiaGpuDevice
+			origBdfToIommu   map[string]string
+			origRegistry     map[string]*GenericDevicePlugin
+		)
+
+		BeforeEach(func() {
+			origReadLink = readLink
+			origReadID = readIDFromFile
+			origReadNUMA = readNUMANode
+			origDeviceMap = deviceMap
+			origIommuMap = iommuMap
+			origBdfToIommu = bdfToIommuMap
+			origRegistry = pluginRegistry
+
+			deviceMap = map[string][]NvidiaGpuDevice{}
+			iommuMap = map[string][]NvidiaGpuDevice{}
+			bdfToIommuMap = map[string]string{}
+			pluginRegistry = map[string]*GenericDevicePlugin{}
+
+			readLink = func(_, _, link string) (string, error) {
+				switch link {
+				case "driver":
+					return "vfio-pci", nil
+				case "iommu_group":
+					return "73", nil
+				}
+				return "", nil
+			}
+			readIDFromFile = func(_, _, prop string) (string, error) {
+				switch prop {
+				case "vendor":
+					return nvidiaVendorID, nil
+				case "device":
+					return "2684", nil
+				}
+				return "", nil
+			}
+			readNUMANode = func(_, _ string) (int64, error) { return 1, nil }
+		})
+
+		AfterEach(func() {
+			readLink = origReadLink
+			readIDFromFile = origReadID
+			readNUMANode = origReadNUMA
+			deviceMap = origDeviceMap
+			iommuMap = origIommuMap
+			bdfToIommuMap = origBdfToIommu
+			pluginRegistry = origRegistry
+		})
+
+		It("registers the BDF in the maps and pushes it to the live plugin", func() {
+			dp := NewGenericDevicePlugin("AD102_GEFORCE_RTX_4090", "/dev/vfio/", []*pluginapi.Device{
+				{ID: "0000:01:00.0", Health: pluginapi.Healthy},
+			})
+			registerPlugin("2684", dp)
+
+			onLateVfioBinding("0000:23:00.0")
+
+			Expect(bdfToIommuMap).To(HaveKeyWithValue("0000:23:00.0", "73"),
+				"the new BDF must appear in bdfToIommuMap so Allocate() can resolve it")
+			Expect(deviceMap["2684"]).To(HaveLen(1))
+			Expect(deviceMap["2684"][0].addr).To(Equal("0000:23:00.0"))
+
+			snap := dp.snapshotDevs()
+			Expect(snap).To(HaveLen(2),
+				"the plugin's pool must grow without a process restart — that is the whole point of v3")
+			ids := []string{snap[0].ID, snap[1].ID}
+			Expect(ids).To(ConsistOf("0000:01:00.0", "0000:23:00.0"))
+
+			select {
+			case <-dp.update:
+				// good — ListAndWatch will re-publish
+			default:
+				Fail("onLateVfioBinding must signal the plugin's update channel so kubelet sees the new device")
+			}
+		})
+
+		It("is a no-op for a BDF already in the maps", func() {
+			dp := NewGenericDevicePlugin("AD102_GEFORCE_RTX_4090", "/dev/vfio/", []*pluginapi.Device{
+				{ID: "0000:23:00.0", Health: pluginapi.Healthy},
+			})
+			registerPlugin("2684", dp)
+			bdfToIommuMap["0000:23:00.0"] = "73"
+			deviceMap["2684"] = []NvidiaGpuDevice{{addr: "0000:23:00.0", numaNode: 1}}
+
+			onLateVfioBinding("0000:23:00.0")
+
+			Expect(dp.snapshotDevs()).To(HaveLen(1),
+				"a duplicate binding event must not double-register the device")
+		})
+	})
+})

--- a/pkg/device_plugin/vfio_busy.go
+++ b/pkg/device_plugin/vfio_busy.go
@@ -30,9 +30,12 @@ package device_plugin
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
+	"slices"
 
 	"golang.org/x/sys/unix"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
 // isVfioGroupBusy reports whether /dev/vfio/<group> is currently held by
@@ -41,11 +44,11 @@ import (
 // open(2) of a group whose `opened` refcount is already 1, so a single
 // non-blocking open is enough to distinguish "free" from "in use".
 //
-// Returning true tells the device plugin to exclude this device from the
-// pool it advertises to kubelet, so a new pod is never assigned a PCI
-// device that is already passed through to another tenant VM — preventing
-// the "Could not open '/dev/vfio/<group>': Device or resource busy" qemu
-// crashloop.
+// Allocate() and GetPreferredAllocation() use this to swap a busy PCI ID
+// for a known-free one in the plugin's pool, so a tenant VM never gets a
+// /dev/vfio/<group> that is already passed through to another VM —
+// preventing the "Could not open '/dev/vfio/<group>': Device or resource
+// busy" qemu crashloop on plugin restart with running tenants present.
 //
 // Overridable for tests.
 var isVfioGroupBusy = isVfioGroupBusyFunc
@@ -68,4 +71,94 @@ func isVfioGroupBusyFunc(group string) bool {
 	}
 	_ = unix.Close(fd)
 	return false
+}
+
+// substituteBusyDevices returns a copy of requested where every PCI ID
+// whose IOMMU group is currently held by another process has been swapped
+// for a free device from pool. The returned slice preserves ordering and
+// is guaranteed not to contain duplicates.
+//
+// Returns an error if a busy device cannot be replaced because the pool
+// has no candidate whose IOMMU group is free (and that is not already
+// part of the response). Callers should surface the error to kubelet so
+// the request is retried rather than producing a guaranteed-failing
+// allocation.
+func substituteBusyDevices(pool []*pluginapi.Device, requested []string, bdfToIommu map[string]string) ([]string, error) {
+	// Two passes so a free requested ID later in the slice is not stolen
+	// by the substitute step for an earlier busy one. First pass reserves
+	// every requested ID we will keep (unknown or non-busy); second pass
+	// picks substitutes from the remainder.
+	keep := make([]bool, len(requested))
+	used := make(map[string]bool, len(requested))
+	for i, bdf := range requested {
+		iommu, ok := bdfToIommu[bdf]
+		if !ok || !isVfioGroupBusy(iommu) {
+			keep[i] = true
+			used[bdf] = true
+		}
+	}
+
+	out := make([]string, len(requested))
+	for i, bdf := range requested {
+		if keep[i] {
+			out[i] = bdf
+			continue
+		}
+		sub, err := pickFreeSubstitute(pool, used, bdfToIommu)
+		if err != nil {
+			return nil, fmt.Errorf("cannot substitute busy device %s (iommu %s): %w", bdf, bdfToIommu[bdf], err)
+		}
+		out[i] = sub
+		used[sub] = true
+	}
+	return out, nil
+}
+
+// pickFreeSubstitute returns the first device in pool whose IOMMU group is
+// not currently held and that is not already in used. Returns an error if
+// no candidate is available.
+func pickFreeSubstitute(pool []*pluginapi.Device, used map[string]bool, bdfToIommu map[string]string) (string, error) {
+	for _, d := range pool {
+		if used[d.ID] {
+			continue
+		}
+		iommu, ok := bdfToIommu[d.ID]
+		if !ok {
+			continue
+		}
+		if isVfioGroupBusy(iommu) {
+			continue
+		}
+		return d.ID, nil
+	}
+	return "", errors.New("no free VFIO group available in the pool")
+}
+
+// filterPreferredFreeDevices returns available with busy devices moved to
+// the end of the slice so kubelet's preferred-allocation pass picks free
+// ones first when the available set is larger than the requested count.
+// Returns the input slice when no busy devices are present, so the caller
+// can detect the no-op case without an allocation.
+func filterPreferredFreeDevices(available []string, bdfToIommu map[string]string) []string {
+	hasBusy := false
+	for _, id := range available {
+		if iommu, ok := bdfToIommu[id]; ok && isVfioGroupBusy(iommu) {
+			hasBusy = true
+			break
+		}
+	}
+	if !hasBusy {
+		return available
+	}
+	free := make([]string, 0, len(available))
+	busy := make([]string, 0)
+	for _, id := range available {
+		iommu, ok := bdfToIommu[id]
+		if ok && isVfioGroupBusy(iommu) {
+			busy = append(busy, id)
+		} else {
+			free = append(free, id)
+		}
+	}
+	return slices.Concat(free, busy)
 }

--- a/pkg/device_plugin/vfio_busy.go
+++ b/pkg/device_plugin/vfio_busy.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package device_plugin
+
+import (
+	"errors"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// isVfioGroupBusy reports whether /dev/vfio/<group> is currently held by
+// another process (typically a running qemu-kvm / virt-launcher with a GPU
+// passed through). The VFIO kernel driver returns EBUSY on the second
+// open(2) of a group whose `opened` refcount is already 1, so a single
+// non-blocking open is enough to distinguish "free" from "in use".
+//
+// Returning true tells the device plugin to exclude this device from the
+// pool it advertises to kubelet, so a new pod is never assigned a PCI
+// device that is already passed through to another tenant VM — preventing
+// the "Could not open '/dev/vfio/<group>': Device or resource busy" qemu
+// crashloop.
+//
+// Overridable for tests.
+var isVfioGroupBusy = isVfioGroupBusyFunc
+
+// vfioGroupBasePath is /dev/vfio. Overridable for tests.
+var vfioGroupBasePath = "/dev/vfio"
+
+func isVfioGroupBusyFunc(group string) bool {
+	path := filepath.Join(vfioGroupBasePath, group)
+	fd, err := unix.Open(path, unix.O_RDWR|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		if errors.Is(err, unix.EBUSY) {
+			return true
+		}
+		// Any other error (ENOENT, EACCES, ...) means we cannot prove the
+		// group is in use. Be conservative and report it as not-busy so a
+		// missing /dev node or permission glitch does not silently shrink
+		// the advertised pool.
+		return false
+	}
+	_ = unix.Close(fd)
+	return false
+}

--- a/pkg/device_plugin/vfio_busy_test.go
+++ b/pkg/device_plugin/vfio_busy_test.go
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package device_plugin
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("vfio-busy", func() {
+
+	Describe("isVfioGroupBusyFunc", func() {
+		var (
+			tmpDir            string
+			origBasePath      string
+			err               error
+		)
+
+		BeforeEach(func() {
+			tmpDir, err = os.MkdirTemp("", "vfio-busy-test")
+			Expect(err).ToNot(HaveOccurred())
+			origBasePath = vfioGroupBasePath
+			vfioGroupBasePath = tmpDir
+		})
+
+		AfterEach(func() {
+			vfioGroupBasePath = origBasePath
+			os.RemoveAll(tmpDir)
+		})
+
+		It("reports not busy when /dev/vfio/<group> is absent", func() {
+			// A transient ENOENT (missing /dev node or wrong mount) must
+			// not silently shrink the advertised pool.
+			Expect(isVfioGroupBusyFunc("does-not-exist")).To(BeFalse())
+		})
+
+		It("reports not busy when the group node opens cleanly", func() {
+			// A regular file stands in for a free vfio group node — it opens
+			// without EBUSY, so the helper must report not busy.
+			groupPath := filepath.Join(tmpDir, "42")
+			Expect(os.WriteFile(groupPath, nil, 0644)).To(Succeed())
+			Expect(isVfioGroupBusyFunc("42")).To(BeFalse())
+		})
+	})
+
+	Describe("createIommuDeviceMap with busy-group filter", func() {
+		var (
+			workDir          string
+			origReadLink     func(string, string, string) (string, error)
+			origReadID       func(string, string, string) (string, error)
+			origIsBusy       func(string) bool
+			origBasePath     string
+			origDeviceMap    map[string][]NvidiaGpuDevice
+			origIommuMap     map[string][]NvidiaGpuDevice
+			origBdfToIommu   map[string]string
+		)
+
+		BeforeEach(func() {
+			var err error
+			workDir, err = os.MkdirTemp("", "vfio-busy-discovery")
+			Expect(err).ToNot(HaveOccurred())
+			linkDir, err := os.MkdirTemp("", "vfio-busy-targets")
+			Expect(err).ToNot(HaveOccurred())
+
+			// createIommuDeviceMap uses filepath.Walk's Lstat, so directories
+			// are skipped. Mirror the existing test pattern: a symlink at
+			// workDir/<BDF> pointing at a real directory under linkDir lets
+			// info.IsDir() return false for the entry while still being a
+			// valid sysfs-like path.
+			for _, bdf := range []string{"0000:23:00.0", "0000:24:00.0"} {
+				target := filepath.Join(linkDir, bdf)
+				Expect(os.Mkdir(target, 0755)).To(Succeed())
+				Expect(os.Symlink(target, filepath.Join(workDir, bdf))).To(Succeed())
+			}
+
+			origBasePath = basePath
+			basePath = workDir
+
+			origReadLink = readLink
+			readLink = func(_, addr, link string) (string, error) {
+				switch link {
+				case "driver":
+					return "vfio-pci", nil
+				case "iommu_group":
+					if addr == "0000:23:00.0" {
+						return "51", nil
+					}
+					return "73", nil
+				}
+				return "", nil
+			}
+
+			origReadID = readIDFromFile
+			readIDFromFile = func(_, _, prop string) (string, error) {
+				switch prop {
+				case "vendor":
+					return nvidiaVendorID, nil
+				case "device":
+					return "2684", nil
+				}
+				return "", nil
+			}
+
+			origIsBusy = isVfioGroupBusy
+			isVfioGroupBusy = func(group string) bool {
+				// 0000:23:00.0 (group 51) is held by another tenant VM.
+				return group == "51"
+			}
+
+			origDeviceMap = deviceMap
+			origIommuMap = iommuMap
+			origBdfToIommu = bdfToIommuMap
+		})
+
+		AfterEach(func() {
+			basePath = origBasePath
+			readLink = origReadLink
+			readIDFromFile = origReadID
+			isVfioGroupBusy = origIsBusy
+			deviceMap = origDeviceMap
+			iommuMap = origIommuMap
+			bdfToIommuMap = origBdfToIommu
+			os.RemoveAll(workDir)
+		})
+
+		It("skips devices whose vfio group is held by another process", func() {
+			createIommuDeviceMap()
+
+			Expect(bdfToIommuMap).NotTo(HaveKey("0000:23:00.0"),
+				"a device whose vfio group is held must not be advertised — otherwise kubelet hands the PCI ID to a new pod and qemu fails with /dev/vfio/<group> EBUSY")
+			Expect(iommuMap).NotTo(HaveKey("51"))
+
+			Expect(bdfToIommuMap).To(HaveKeyWithValue("0000:24:00.0", "73"),
+				"a device whose vfio group is free must still be discovered")
+			Expect(iommuMap).To(HaveKey("73"))
+		})
+	})
+})

--- a/pkg/device_plugin/vfio_busy_test.go
+++ b/pkg/device_plugin/vfio_busy_test.go
@@ -34,6 +34,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
 var _ = Describe("vfio-busy", func() {
@@ -72,96 +74,72 @@ var _ = Describe("vfio-busy", func() {
 		})
 	})
 
-	Describe("createIommuDeviceMap with busy-group filter", func() {
+	Describe("createDevicePlugins marks busy-group GPUs Unhealthy", func() {
 		var (
-			workDir          string
-			origReadLink     func(string, string, string) (string, error)
-			origReadID       func(string, string, string) (string, error)
-			origIsBusy       func(string) bool
-			origBasePath     string
-			origDeviceMap    map[string][]NvidiaGpuDevice
-			origIommuMap     map[string][]NvidiaGpuDevice
-			origBdfToIommu   map[string]string
+			origIsBusy     func(string) bool
+			origDeviceMap  map[string][]NvidiaGpuDevice
+			origBdfToIommu map[string]string
+			origStart      func(*GenericDevicePlugin) error
+			started        []*GenericDevicePlugin
 		)
 
 		BeforeEach(func() {
-			var err error
-			workDir, err = os.MkdirTemp("", "vfio-busy-discovery")
-			Expect(err).ToNot(HaveOccurred())
-			linkDir, err := os.MkdirTemp("", "vfio-busy-targets")
-			Expect(err).ToNot(HaveOccurred())
+			origDeviceMap = deviceMap
+			origBdfToIommu = bdfToIommuMap
 
-			// createIommuDeviceMap uses filepath.Walk's Lstat, so directories
-			// are skipped. Mirror the existing test pattern: a symlink at
-			// workDir/<BDF> pointing at a real directory under linkDir lets
-			// info.IsDir() return false for the entry while still being a
-			// valid sysfs-like path.
-			for _, bdf := range []string{"0000:23:00.0", "0000:24:00.0"} {
-				target := filepath.Join(linkDir, bdf)
-				Expect(os.Mkdir(target, 0755)).To(Succeed())
-				Expect(os.Symlink(target, filepath.Join(workDir, bdf))).To(Succeed())
+			// Two NVIDIA GPUs of the same device id sharing a single plugin:
+			// 0000:23:00.0 → group 51 (busy, held by another tenant VM)
+			// 0000:24:00.0 → group 73 (free)
+			deviceMap = map[string][]NvidiaGpuDevice{
+				"2684": {
+					{addr: "0000:23:00.0", numaNode: 0},
+					{addr: "0000:24:00.0", numaNode: 0},
+				},
 			}
-
-			origBasePath = basePath
-			basePath = workDir
-
-			origReadLink = readLink
-			readLink = func(_, addr, link string) (string, error) {
-				switch link {
-				case "driver":
-					return "vfio-pci", nil
-				case "iommu_group":
-					if addr == "0000:23:00.0" {
-						return "51", nil
-					}
-					return "73", nil
-				}
-				return "", nil
-			}
-
-			origReadID = readIDFromFile
-			readIDFromFile = func(_, _, prop string) (string, error) {
-				switch prop {
-				case "vendor":
-					return nvidiaVendorID, nil
-				case "device":
-					return "2684", nil
-				}
-				return "", nil
+			bdfToIommuMap = map[string]string{
+				"0000:23:00.0": "51",
+				"0000:24:00.0": "73",
 			}
 
 			origIsBusy = isVfioGroupBusy
-			isVfioGroupBusy = func(group string) bool {
-				// 0000:23:00.0 (group 51) is held by another tenant VM.
-				return group == "51"
-			}
+			isVfioGroupBusy = func(group string) bool { return group == "51" }
 
-			origDeviceMap = deviceMap
-			origIommuMap = iommuMap
-			origBdfToIommu = bdfToIommuMap
+			origStart = startDevicePlugin
+			started = nil
+			startDevicePlugin = func(dp *GenericDevicePlugin) error {
+				started = append(started, dp)
+				return nil
+			}
 		})
 
 		AfterEach(func() {
-			basePath = origBasePath
-			readLink = origReadLink
-			readIDFromFile = origReadID
-			isVfioGroupBusy = origIsBusy
 			deviceMap = origDeviceMap
-			iommuMap = origIommuMap
 			bdfToIommuMap = origBdfToIommu
-			os.RemoveAll(workDir)
+			isVfioGroupBusy = origIsBusy
+			startDevicePlugin = origStart
 		})
 
-		It("skips devices whose vfio group is held by another process", func() {
-			createIommuDeviceMap()
+		It("keeps busy GPUs in the pool but marks them Unhealthy", func() {
+			// createDevicePlugins blocks on the package stop channel after
+			// constructing the plugins. Run it in a goroutine, give it a
+			// moment to populate `started`, then unblock it.
+			go createDevicePlugins()
+			Eventually(func() int { return len(started) }, "2s", "20ms").
+				Should(Equal(1), "a single plugin is created per device id (here 2684)")
+			stop <- struct{}{}
 
-			Expect(bdfToIommuMap).NotTo(HaveKey("0000:23:00.0"),
-				"a device whose vfio group is held must not be advertised — otherwise kubelet hands the PCI ID to a new pod and qemu fails with /dev/vfio/<group> EBUSY")
-			Expect(iommuMap).NotTo(HaveKey("51"))
+			devsByID := map[string]string{}
+			for _, d := range started[0].devs {
+				devsByID[d.ID] = d.Health
+			}
 
-			Expect(bdfToIommuMap).To(HaveKeyWithValue("0000:24:00.0", "73"),
-				"a device whose vfio group is free must still be discovered")
-			Expect(iommuMap).To(HaveKey("73"))
+			Expect(devsByID).To(HaveKey("0000:23:00.0"),
+				"a busy GPU must stay in the advertised pool so kubelet's capacity accounting is correct and the existing-pod allocation is preserved")
+			Expect(devsByID["0000:23:00.0"]).To(Equal(pluginapi.Unhealthy),
+				"a busy GPU must be Unhealthy so kubelet does not hand the same PCI ID to a new pod — which would crashloop in qemu with /dev/vfio/<group> EBUSY")
+
+			Expect(devsByID).To(HaveKeyWithValue("0000:24:00.0", pluginapi.Healthy),
+				"a free GPU must remain Healthy and available for allocation")
 		})
 	})
 })

--- a/pkg/device_plugin/vfio_busy_test.go
+++ b/pkg/device_plugin/vfio_busy_test.go
@@ -74,7 +74,7 @@ var _ = Describe("vfio-busy", func() {
 		})
 	})
 
-	Describe("createDevicePlugins marks busy-group GPUs Unhealthy", func() {
+	Describe("createDevicePlugins keeps all vfio-bound GPUs Healthy", func() {
 		var (
 			origIsBusy     func(string) bool
 			origDeviceMap  map[string][]NvidiaGpuDevice
@@ -119,7 +119,7 @@ var _ = Describe("vfio-busy", func() {
 			startDevicePlugin = origStart
 		})
 
-		It("keeps busy GPUs in the pool but marks them Unhealthy", func() {
+		It("keeps the full pool Healthy regardless of current vfio-busy state", func() {
 			// createDevicePlugins blocks on the package stop channel after
 			// constructing the plugins. Run it in a goroutine, give it a
 			// moment to populate `started`, then unblock it.
@@ -133,13 +133,101 @@ var _ = Describe("vfio-busy", func() {
 				devsByID[d.ID] = d.Health
 			}
 
-			Expect(devsByID).To(HaveKey("0000:23:00.0"),
-				"a busy GPU must stay in the advertised pool so kubelet's capacity accounting is correct and the existing-pod allocation is preserved")
-			Expect(devsByID["0000:23:00.0"]).To(Equal(pluginapi.Unhealthy),
-				"a busy GPU must be Unhealthy so kubelet does not hand the same PCI ID to a new pod — which would crashloop in qemu with /dev/vfio/<group> EBUSY")
-
+			// Capacity must reflect the physical hardware — platform-api
+			// computes "available" as allocatable − sum(GPUs of running
+			// instances), so shrinking allocatable when devices are in
+			// passthrough double-subtracts and reports negative free GPUs.
+			Expect(devsByID).To(HaveKeyWithValue("0000:23:00.0", pluginapi.Healthy),
+				"a busy GPU must still be Healthy so node capacity reflects physical hardware; the in-use check is enforced in Allocate()")
 			Expect(devsByID).To(HaveKeyWithValue("0000:24:00.0", pluginapi.Healthy),
-				"a free GPU must remain Healthy and available for allocation")
+				"a free GPU must of course be Healthy")
+		})
+	})
+
+	Describe("substituteBusyDevices", func() {
+		var (
+			origIsBusy func(string) bool
+			pool       []*pluginapi.Device
+			bdfToIommu map[string]string
+		)
+
+		BeforeEach(func() {
+			// Pool of three devices, all known to the plugin.
+			pool = []*pluginapi.Device{
+				{ID: "0000:23:00.0"},
+				{ID: "0000:24:00.0"},
+				{ID: "0000:25:00.0"},
+			}
+			bdfToIommu = map[string]string{
+				"0000:23:00.0": "51",
+				"0000:24:00.0": "73",
+				"0000:25:00.0": "95",
+			}
+
+			origIsBusy = isVfioGroupBusy
+		})
+
+		AfterEach(func() {
+			isVfioGroupBusy = origIsBusy
+		})
+
+		It("returns requested IDs unchanged when none are busy", func() {
+			isVfioGroupBusy = func(string) bool { return false }
+			out, err := substituteBusyDevices(pool, []string{"0000:23:00.0", "0000:24:00.0"}, bdfToIommu)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(Equal([]string{"0000:23:00.0", "0000:24:00.0"}))
+		})
+
+		It("substitutes a busy device with a free one from the pool", func() {
+			// Only group 51 (BDF 0000:23:00.0) is busy.
+			isVfioGroupBusy = func(g string) bool { return g == "51" }
+			out, err := substituteBusyDevices(pool, []string{"0000:23:00.0"}, bdfToIommu)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(HaveLen(1))
+			Expect(out[0]).ToNot(Equal("0000:23:00.0"), "the busy ID must be replaced")
+			Expect(bdfToIommu[out[0]]).To(BeElementOf("73", "95"), "the substitute must be a known-free device")
+		})
+
+		It("does not pick a substitute that is already part of the response", func() {
+			// 51 busy, 73 free, 95 also busy → only one free candidate, but
+			// kubelet asked for two devices. We must surface an error rather
+			// than return a duplicate (which would crash qemu later).
+			isVfioGroupBusy = func(g string) bool { return g == "51" || g == "95" }
+			_, err := substituteBusyDevices(pool, []string{"0000:23:00.0", "0000:25:00.0"}, bdfToIommu)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no free VFIO group available"))
+		})
+
+		It("keeps healthy + swap combinations consistent (free ID retained, busy ID swapped)", func() {
+			// 51 busy, 73 free, 95 free. kubelet asks for [23 (busy), 24 (free)].
+			// Expect: [<swap of 23 → some free other than 24>, 24]
+			isVfioGroupBusy = func(g string) bool { return g == "51" }
+			out, err := substituteBusyDevices(pool, []string{"0000:23:00.0", "0000:24:00.0"}, bdfToIommu)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(HaveLen(2))
+			Expect(out[1]).To(Equal("0000:24:00.0"), "a free requested ID must not be touched")
+			Expect(out[0]).To(Equal("0000:25:00.0"), "the swap should pick the next free device, skipping ones already in the response")
+		})
+	})
+
+	Describe("filterPreferredFreeDevices", func() {
+		var origIsBusy func(string) bool
+
+		BeforeEach(func() { origIsBusy = isVfioGroupBusy })
+		AfterEach(func() { isVfioGroupBusy = origIsBusy })
+
+		It("returns the slice unchanged when no devices are busy", func() {
+			isVfioGroupBusy = func(string) bool { return false }
+			in := []string{"a", "b", "c"}
+			bdfToIommu := map[string]string{"a": "1", "b": "2", "c": "3"}
+			Expect(filterPreferredFreeDevices(in, bdfToIommu)).To(Equal(in))
+		})
+
+		It("moves busy devices to the end so kubelet picks free ones first", func() {
+			isVfioGroupBusy = func(g string) bool { return g == "1" || g == "3" }
+			bdfToIommu := map[string]string{"a": "1", "b": "2", "c": "3", "d": "4"}
+			out := filterPreferredFreeDevices([]string{"a", "b", "c", "d"}, bdfToIommu)
+			Expect(out).To(Equal([]string{"b", "d", "a", "c"}))
 		})
 	})
 })

--- a/pkg/device_plugin/vfio_watcher.go
+++ b/pkg/device_plugin/vfio_watcher.go
@@ -1,11 +1,29 @@
 /*
- * Copyright (c) 2026, HiveNet. All rights reserved.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 package device_plugin

--- a/pkg/device_plugin/vfio_watcher.go
+++ b/pkg/device_plugin/vfio_watcher.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, HiveNet. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package device_plugin
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const pciDriversBasePath = "/sys/bus/pci/drivers"
+
+var stopOnce sync.Once
+
+// watchVfioBindings detects NVIDIA GPUs bound to a supported VFIO driver
+// after this process completed its initial discovery, and triggers an orderly
+// shutdown so the kubelet recreates the pod and re-runs discovery.
+//
+// This closes a startup race with nvidia-vfio-manager: createIommuDeviceMap
+// runs once in InitiateDevicePlugin, so any GPU bound to a VFIO driver
+// afterwards is invisible to kubelet — and therefore unschedulable — until the
+// plugin pod is restarted by hand or by an external watchdog.
+func watchVfioBindings(stop chan struct{}) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Printf("vfio-watcher: cannot create fsnotify watcher: %v", err)
+		return
+	}
+	defer watcher.Close()
+
+	baseline := nvidiaVfioBdfs()
+	watchedDrivers := make([]string, 0, len(supportedVfioDrivers))
+	for driver := range supportedVfioDrivers {
+		path := filepath.Join(pciDriversBasePath, driver)
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		if err := watcher.Add(path); err != nil {
+			log.Printf("vfio-watcher: cannot watch %s: %v", path, err)
+			continue
+		}
+		watchedDrivers = append(watchedDrivers, driver)
+	}
+	if len(watchedDrivers) == 0 {
+		log.Printf("vfio-watcher: no supported VFIO driver directories present, exiting")
+		return
+	}
+	log.Printf("vfio-watcher: watching drivers=%v; baseline=%d NVIDIA GPU(s)", watchedDrivers, len(baseline))
+
+	// Re-check after Add to close the race window between baseline capture
+	// and the watcher becoming active.
+	if extra := newNvidiaBdfs(baseline); len(extra) > 0 {
+		triggerRestart(stop, "post-baseline rescan found new NVIDIA GPU(s): "+strings.Join(extra, ","))
+		return
+	}
+
+	for {
+		select {
+		case <-stop:
+			return
+		case ev, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			if ev.Op&fsnotify.Create == 0 {
+				continue
+			}
+			bdf := filepath.Base(ev.Name)
+			if !isPCIAddress(bdf) {
+				continue
+			}
+			if _, seen := baseline[bdf]; seen {
+				continue
+			}
+			vendor, err := readIDFromFile(basePath, bdf, "vendor")
+			if err != nil || vendor != nvidiaVendorID {
+				continue
+			}
+			triggerRestart(stop, "new NVIDIA GPU "+bdf+" bound to a VFIO driver")
+			return
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("vfio-watcher: error: %v", err)
+		}
+	}
+}
+
+// nvidiaVfioBdfs returns the set of NVIDIA PCI addresses currently bound to
+// any supported VFIO driver.
+func nvidiaVfioBdfs() map[string]struct{} {
+	s := make(map[string]struct{})
+	for driver := range supportedVfioDrivers {
+		entries, err := os.ReadDir(filepath.Join(pciDriversBasePath, driver))
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			bdf := e.Name()
+			if !isPCIAddress(bdf) {
+				continue
+			}
+			vendor, err := readIDFromFile(basePath, bdf, "vendor")
+			if err == nil && vendor == nvidiaVendorID {
+				s[bdf] = struct{}{}
+			}
+		}
+	}
+	return s
+}
+
+// newNvidiaBdfs returns NVIDIA BDFs currently bound to a VFIO driver but
+// absent from baseline.
+func newNvidiaBdfs(baseline map[string]struct{}) []string {
+	var extra []string
+	for bdf := range nvidiaVfioBdfs() {
+		if _, ok := baseline[bdf]; !ok {
+			extra = append(extra, bdf)
+		}
+	}
+	return extra
+}
+
+// isPCIAddress reports whether s looks like a PCI BDF (e.g. "0000:01:00.0").
+// This filters out non-device entries the kernel exposes under driver dirs
+// (e.g. "bind", "unbind", "new_id", "module").
+func isPCIAddress(s string) bool {
+	return strings.HasPrefix(s, "0000:") && strings.ContainsRune(s, '.')
+}
+
+func triggerRestart(stop chan struct{}, reason string) {
+	log.Printf("vfio-watcher: triggering plugin restart: %s", reason)
+	stopOnce.Do(func() {
+		close(stop)
+	})
+}

--- a/pkg/device_plugin/vfio_watcher.go
+++ b/pkg/device_plugin/vfio_watcher.go
@@ -35,7 +35,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/fsnotify/fsnotify"
 )
@@ -54,19 +53,34 @@ var nvidiaVfioBdfs = nvidiaVfioBdfsFunc
 // rejects sysfs control entries like "bind", "unbind", "new_id", "module".
 var pciAddressRe = regexp.MustCompile(`^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]$`)
 
+// onNewVfioBdf is the watcher's callback for each new NVIDIA PCI device
+// bound to a supported VFIO driver. Overridable for tests. Default:
+// onLateVfioBinding in device_plugin.go, which registers the BDF in the
+// in-memory maps and pushes the device into the live ListAndWatch stream of
+// the matching plugin.
+var onNewVfioBdf = func(bdf string) {
+	onLateVfioBinding(bdf)
+}
+
 // watchVfioBindings detects NVIDIA GPUs bound to a supported VFIO driver
-// after this process completed its initial discovery, and triggers an orderly
-// shutdown so the kubelet recreates the pod and re-runs discovery.
+// after this process completed its initial discovery and incrementally
+// registers each one via onNewVfioBdf — no process restart, so kubelet's
+// device-manager checkpoint and the existing tenant pod allocations are
+// never invalidated.
 //
-// This closes a startup race with nvidia-vfio-manager: createIommuDeviceMap
-// runs once in InitiateDevicePlugin, so any GPU bound to a VFIO driver
-// afterwards is invisible to kubelet — and therefore unschedulable — until
-// the plugin pod is restarted by hand or by an external watchdog.
+// Earlier versions closed stop on the first new binding to trigger a
+// container restart. That worked for the original symptom (advertise GPUs
+// bound after startup) but introduced a subtler bug on multi-tenant GPU
+// nodes: kubelet had to reconcile its pre-restart device set against the
+// post-restart ListAndWatch frames, and during that window in-flight pod
+// allocations to busy GPUs could be either dropped or double-handed-out —
+// qemu then failed to open /dev/vfio/<group> with EBUSY. Live incremental
+// updates avoid the whole reconciliation window.
 //
-// The watcher captures a baseline of currently-bound NVIDIA BDFs before
-// adding the fsnotify watch, then re-scans immediately after Add to close
-// the race window between baseline capture and watcher activation. A new BDF
-// after either point closes stop exactly once via a per-call sync.Once.
+// The watcher still captures a baseline of currently-bound NVIDIA BDFs
+// before adding the fsnotify watch and re-scans immediately after Add to
+// close the race window between baseline capture and watcher activation.
+// Each new BDF is dispatched exactly once via the baseline set.
 func watchVfioBindings(stop chan struct{}) {
 	const method = "vfio-watcher"
 
@@ -76,14 +90,6 @@ func watchVfioBindings(stop chan struct{}) {
 		return
 	}
 	defer watcher.Close()
-
-	var once sync.Once
-	closeStop := func(reason string) {
-		once.Do(func() {
-			log.Printf("%s: triggering plugin restart: %s", method, reason)
-			close(stop)
-		})
-	}
 
 	baseline := nvidiaVfioBdfs()
 
@@ -97,8 +103,11 @@ func watchVfioBindings(stop chan struct{}) {
 	// Re-check after Add to close the race window between baseline capture
 	// and watcher activation.
 	if extra := newNvidiaBdfs(baseline); len(extra) > 0 {
-		closeStop("post-baseline rescan found new NVIDIA GPU(s): " + joinSorted(extra))
-		return
+		log.Printf("%s: post-baseline rescan found new NVIDIA GPU(s): %s", method, joinSorted(extra))
+		for _, bdf := range extra {
+			onNewVfioBdf(bdf)
+			baseline[bdf] = struct{}{}
+		}
 	}
 
 	for {
@@ -112,8 +121,10 @@ func watchVfioBindings(stop chan struct{}) {
 			if !isNewNvidiaBinding(ev, baseline) {
 				continue
 			}
-			closeStop("new NVIDIA GPU " + filepath.Base(ev.Name) + " bound to a VFIO driver")
-			return
+			bdf := filepath.Base(ev.Name)
+			log.Printf("%s: new NVIDIA GPU %s bound to a VFIO driver — registering live", method, bdf)
+			onNewVfioBdf(bdf)
+			baseline[bdf] = struct{}{}
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				return

--- a/pkg/device_plugin/vfio_watcher.go
+++ b/pkg/device_plugin/vfio_watcher.go
@@ -53,35 +53,26 @@ var nvidiaVfioBdfs = nvidiaVfioBdfsFunc
 // rejects sysfs control entries like "bind", "unbind", "new_id", "module".
 var pciAddressRe = regexp.MustCompile(`^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]$`)
 
-// onNewVfioBdf is the watcher's callback for each new NVIDIA PCI device
-// bound to a supported VFIO driver. Overridable for tests. Default:
-// onLateVfioBinding in device_plugin.go, which registers the BDF in the
-// in-memory maps and pushes the device into the live ListAndWatch stream of
-// the matching plugin.
-var onNewVfioBdf = func(bdf string) {
-	onLateVfioBinding(bdf)
-}
-
-// watchVfioBindings detects NVIDIA GPUs bound to a supported VFIO driver
-// after this process completed its initial discovery and incrementally
-// registers each one via onNewVfioBdf — no process restart, so kubelet's
-// device-manager checkpoint and the existing tenant pod allocations are
-// never invalidated.
+// watchVfioBindings reports every NVIDIA PCI device that becomes bound to a
+// supported VFIO driver after the initial discovery, by invoking onBound for
+// each new BDF. It does not exit the process — the plugin keeps running and
+// the caller is expected to publish the new device through its live
+// ListAndWatch stream.
 //
-// Earlier versions closed stop on the first new binding to trigger a
-// container restart. That worked for the original symptom (advertise GPUs
-// bound after startup) but introduced a subtler bug on multi-tenant GPU
-// nodes: kubelet had to reconcile its pre-restart device set against the
-// post-restart ListAndWatch frames, and during that window in-flight pod
-// allocations to busy GPUs could be either dropped or double-handed-out —
-// qemu then failed to open /dev/vfio/<group> with EBUSY. Live incremental
-// updates avoid the whole reconciliation window.
+// Earlier versions of this watcher closed a stop channel on the first new
+// binding to trigger a container restart. That worked for the original
+// symptom but introduced a subtler bug on multi-tenant GPU nodes: kubelet
+// had to reconcile its pre-restart device set against the post-restart
+// ListAndWatch frames, and during that window in-flight pod allocations
+// could be dropped or double-handed-out — qemu then failed to open
+// /dev/vfio/<group> with EBUSY. Live incremental updates avoid the whole
+// reconciliation window.
 //
-// The watcher still captures a baseline of currently-bound NVIDIA BDFs
-// before adding the fsnotify watch and re-scans immediately after Add to
-// close the race window between baseline capture and watcher activation.
-// Each new BDF is dispatched exactly once via the baseline set.
-func watchVfioBindings(stop chan struct{}) {
+// The watcher captures a baseline of currently-bound NVIDIA BDFs before
+// adding the fsnotify watch and re-scans immediately after Add to close the
+// race between baseline capture and watcher activation. Each new BDF is
+// dispatched exactly once via the baseline set.
+func watchVfioBindings(stop <-chan struct{}, onBound func(bdf string)) {
 	const method = "vfio-watcher"
 
 	watcher, err := fsnotify.NewWatcher()
@@ -105,7 +96,7 @@ func watchVfioBindings(stop chan struct{}) {
 	if extra := newNvidiaBdfs(baseline); len(extra) > 0 {
 		log.Printf("%s: post-baseline rescan found new NVIDIA GPU(s): %s", method, joinSorted(extra))
 		for _, bdf := range extra {
-			onNewVfioBdf(bdf)
+			onBound(bdf)
 			baseline[bdf] = struct{}{}
 		}
 	}
@@ -122,8 +113,8 @@ func watchVfioBindings(stop chan struct{}) {
 				continue
 			}
 			bdf := filepath.Base(ev.Name)
-			log.Printf("%s: new NVIDIA GPU %s bound to a VFIO driver — registering live", method, bdf)
-			onNewVfioBdf(bdf)
+			log.Printf("%s: new NVIDIA GPU %s bound to a VFIO driver", method, bdf)
+			onBound(bdf)
 			baseline[bdf] = struct{}{}
 		case err, ok := <-watcher.Errors:
 			if !ok {

--- a/pkg/device_plugin/vfio_watcher.go
+++ b/pkg/device_plugin/vfio_watcher.go
@@ -32,15 +32,27 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
 )
 
-const pciDriversBasePath = "/sys/bus/pci/drivers"
+// pciDriversBasePath is the sysfs root under which each PCI driver exposes a
+// directory containing symlinks for the BDFs it owns. Overridable for tests.
+var pciDriversBasePath = "/sys/bus/pci/drivers"
 
-var stopOnce sync.Once
+// nvidiaVfioBdfs returns the set of NVIDIA PCI BDFs currently bound to any
+// supported VFIO driver. Overridable for tests.
+var nvidiaVfioBdfs = nvidiaVfioBdfsFunc
+
+// pciAddressRe matches the canonical PCI BDF format
+// "domain:bus:device.function" — domain (4 hex), bus (2 hex), device (2 hex),
+// function (1 hex). Stricter than a "0000:" prefix check, so it correctly
+// rejects sysfs control entries like "bind", "unbind", "new_id", "module".
+var pciAddressRe = regexp.MustCompile(`^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]$`)
 
 // watchVfioBindings detects NVIDIA GPUs bound to a supported VFIO driver
 // after this process completed its initial discovery, and triggers an orderly
@@ -48,39 +60,44 @@ var stopOnce sync.Once
 //
 // This closes a startup race with nvidia-vfio-manager: createIommuDeviceMap
 // runs once in InitiateDevicePlugin, so any GPU bound to a VFIO driver
-// afterwards is invisible to kubelet — and therefore unschedulable — until the
-// plugin pod is restarted by hand or by an external watchdog.
+// afterwards is invisible to kubelet — and therefore unschedulable — until
+// the plugin pod is restarted by hand or by an external watchdog.
+//
+// The watcher captures a baseline of currently-bound NVIDIA BDFs before
+// adding the fsnotify watch, then re-scans immediately after Add to close
+// the race window between baseline capture and watcher activation. A new BDF
+// after either point closes stop exactly once via a per-call sync.Once.
 func watchVfioBindings(stop chan struct{}) {
+	const method = "vfio-watcher"
+
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		log.Printf("vfio-watcher: cannot create fsnotify watcher: %v", err)
+		log.Printf("%s: cannot create fsnotify watcher: %v", method, err)
 		return
 	}
 	defer watcher.Close()
 
-	baseline := nvidiaVfioBdfs()
-	watchedDrivers := make([]string, 0, len(supportedVfioDrivers))
-	for driver := range supportedVfioDrivers {
-		path := filepath.Join(pciDriversBasePath, driver)
-		if _, err := os.Stat(path); err != nil {
-			continue
-		}
-		if err := watcher.Add(path); err != nil {
-			log.Printf("vfio-watcher: cannot watch %s: %v", path, err)
-			continue
-		}
-		watchedDrivers = append(watchedDrivers, driver)
+	var once sync.Once
+	closeStop := func(reason string) {
+		once.Do(func() {
+			log.Printf("%s: triggering plugin restart: %s", method, reason)
+			close(stop)
+		})
 	}
-	if len(watchedDrivers) == 0 {
-		log.Printf("vfio-watcher: no supported VFIO driver directories present, exiting")
+
+	baseline := nvidiaVfioBdfs()
+
+	watched := addSupportedDriverWatches(watcher)
+	if len(watched) == 0 {
+		log.Printf("%s: no supported VFIO driver directories present, exiting", method)
 		return
 	}
-	log.Printf("vfio-watcher: watching drivers=%v; baseline=%d NVIDIA GPU(s)", watchedDrivers, len(baseline))
+	log.Printf("%s: watching drivers=%v; baseline=%d NVIDIA GPU(s)", method, watched, len(baseline))
 
 	// Re-check after Add to close the race window between baseline capture
-	// and the watcher becoming active.
+	// and watcher activation.
 	if extra := newNvidiaBdfs(baseline); len(extra) > 0 {
-		triggerRestart(stop, "post-baseline rescan found new NVIDIA GPU(s): "+strings.Join(extra, ","))
+		closeStop("post-baseline rescan found new NVIDIA GPU(s): " + joinSorted(extra))
 		return
 	}
 
@@ -92,35 +109,64 @@ func watchVfioBindings(stop chan struct{}) {
 			if !ok {
 				return
 			}
-			if ev.Op&fsnotify.Create == 0 {
+			if !isNewNvidiaBinding(ev, baseline) {
 				continue
 			}
-			bdf := filepath.Base(ev.Name)
-			if !isPCIAddress(bdf) {
-				continue
-			}
-			if _, seen := baseline[bdf]; seen {
-				continue
-			}
-			vendor, err := readIDFromFile(basePath, bdf, "vendor")
-			if err != nil || vendor != nvidiaVendorID {
-				continue
-			}
-			triggerRestart(stop, "new NVIDIA GPU "+bdf+" bound to a VFIO driver")
+			closeStop("new NVIDIA GPU " + filepath.Base(ev.Name) + " bound to a VFIO driver")
 			return
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				return
 			}
-			log.Printf("vfio-watcher: error: %v", err)
+			log.Printf("%s: error: %v", method, err)
 		}
 	}
 }
 
-// nvidiaVfioBdfs returns the set of NVIDIA PCI addresses currently bound to
-// any supported VFIO driver.
-func nvidiaVfioBdfs() map[string]struct{} {
-	s := make(map[string]struct{})
+// addSupportedDriverWatches adds an fsnotify watch for every entry in
+// supportedVfioDrivers whose directory exists, returning the names of those
+// successfully watched (sorted). Drivers not loaded on the host are silently
+// skipped.
+func addSupportedDriverWatches(watcher *fsnotify.Watcher) []string {
+	const method = "vfio-watcher"
+	watched := make([]string, 0, len(supportedVfioDrivers))
+	for driver := range supportedVfioDrivers {
+		path := filepath.Join(pciDriversBasePath, driver)
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		if err := watcher.Add(path); err != nil {
+			log.Printf("%s: cannot watch %s: %v", method, path, err)
+			continue
+		}
+		watched = append(watched, driver)
+	}
+	sort.Strings(watched)
+	return watched
+}
+
+// isNewNvidiaBinding reports whether ev is a Create event for a previously
+// unseen NVIDIA-vendor PCI device. It rejects non-Create events, sysfs
+// control entries (bind/unbind/...), already-baselined BDFs, and devices
+// from other vendors.
+func isNewNvidiaBinding(ev fsnotify.Event, baseline map[string]struct{}) bool {
+	if ev.Op&fsnotify.Create == 0 {
+		return false
+	}
+	bdf := filepath.Base(ev.Name)
+	if !isPCIAddress(bdf) {
+		return false
+	}
+	if _, seen := baseline[bdf]; seen {
+		return false
+	}
+	vendor, err := readIDFromFile(basePath, bdf, "vendor")
+	return err == nil && vendor == nvidiaVendorID
+}
+
+// nvidiaVfioBdfsFunc is the production implementation of nvidiaVfioBdfs.
+func nvidiaVfioBdfsFunc() map[string]struct{} {
+	out := make(map[string]struct{})
 	for driver := range supportedVfioDrivers {
 		entries, err := os.ReadDir(filepath.Join(pciDriversBasePath, driver))
 		if err != nil {
@@ -133,11 +179,11 @@ func nvidiaVfioBdfs() map[string]struct{} {
 			}
 			vendor, err := readIDFromFile(basePath, bdf, "vendor")
 			if err == nil && vendor == nvidiaVendorID {
-				s[bdf] = struct{}{}
+				out[bdf] = struct{}{}
 			}
 		}
 	}
-	return s
+	return out
 }
 
 // newNvidiaBdfs returns NVIDIA BDFs currently bound to a VFIO driver but
@@ -152,16 +198,18 @@ func newNvidiaBdfs(baseline map[string]struct{}) []string {
 	return extra
 }
 
-// isPCIAddress reports whether s looks like a PCI BDF (e.g. "0000:01:00.0").
-// This filters out non-device entries the kernel exposes under driver dirs
-// (e.g. "bind", "unbind", "new_id", "module").
+// isPCIAddress reports whether s is a canonical PCI BDF
+// (e.g. "0000:01:00.0"). Filters out sysfs control entries the kernel
+// exposes under driver dirs (bind, unbind, new_id, module, etc.).
 func isPCIAddress(s string) bool {
-	return strings.HasPrefix(s, "0000:") && strings.ContainsRune(s, '.')
+	return pciAddressRe.MatchString(s)
 }
 
-func triggerRestart(stop chan struct{}, reason string) {
-	log.Printf("vfio-watcher: triggering plugin restart: %s", reason)
-	stopOnce.Do(func() {
-		close(stop)
-	})
+// joinSorted returns s with entries sorted ascending and comma-joined, so
+// log output is deterministic regardless of map iteration order.
+func joinSorted(s []string) string {
+	cp := make([]string, len(s))
+	copy(cp, s)
+	sort.Strings(cp)
+	return strings.Join(cp, ",")
 }

--- a/pkg/device_plugin/vfio_watcher_test.go
+++ b/pkg/device_plugin/vfio_watcher_test.go
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package device_plugin
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+var _ = Describe("vfio-watcher", func() {
+
+	Describe("isPCIAddress", func() {
+		DescribeTable("recognises canonical BDFs and rejects sysfs control entries",
+			func(in string, want bool) {
+				Expect(isPCIAddress(in)).To(Equal(want))
+			},
+			Entry("simple BDF", "0000:01:00.0", true),
+			Entry("upper bus", "0000:c1:00.1", true),
+			Entry("non-zero domain", "abcd:01:00.0", true),
+			Entry("max function digit", "0000:01:00.f", true),
+			Entry("missing domain", "01:00.0", false),
+			Entry("uppercase hex (sysfs is lowercase)", "0000:0A:00.0", false),
+			Entry("control entry bind", "bind", false),
+			Entry("control entry unbind", "unbind", false),
+			Entry("control entry new_id", "new_id", false),
+			Entry("control entry module", "module", false),
+			Entry("trailing junk", "0000:01:00.0.tmp", false),
+			Entry("empty", "", false),
+		)
+	})
+
+	Describe("joinSorted", func() {
+		It("sorts entries ascending and comma-joins them", func() {
+			Expect(joinSorted([]string{"0000:c1:00.0", "0000:01:00.0", "0000:23:00.0"})).
+				To(Equal("0000:01:00.0,0000:23:00.0,0000:c1:00.0"))
+		})
+		It("returns empty string for empty input", func() {
+			Expect(joinSorted(nil)).To(Equal(""))
+		})
+	})
+
+	Describe("newNvidiaBdfs", func() {
+		var origNvidiaVfioBdfs func() map[string]struct{}
+
+		BeforeEach(func() {
+			origNvidiaVfioBdfs = nvidiaVfioBdfs
+		})
+		AfterEach(func() {
+			nvidiaVfioBdfs = origNvidiaVfioBdfs
+		})
+
+		It("returns BDFs present now but absent from baseline", func() {
+			nvidiaVfioBdfs = func() map[string]struct{} {
+				return map[string]struct{}{
+					"0000:01:00.0": {},
+					"0000:23:00.0": {},
+					"0000:41:00.0": {},
+				}
+			}
+			baseline := map[string]struct{}{
+				"0000:01:00.0": {},
+			}
+			Expect(newNvidiaBdfs(baseline)).To(ConsistOf("0000:23:00.0", "0000:41:00.0"))
+		})
+
+		It("returns nil when nothing new appeared", func() {
+			nvidiaVfioBdfs = func() map[string]struct{} {
+				return map[string]struct{}{"0000:01:00.0": {}}
+			}
+			baseline := map[string]struct{}{"0000:01:00.0": {}}
+			Expect(newNvidiaBdfs(baseline)).To(BeEmpty())
+		})
+	})
+
+	Describe("isNewNvidiaBinding", func() {
+		var origReadID func(string, string, string) (string, error)
+
+		BeforeEach(func() {
+			origReadID = readIDFromFile
+		})
+		AfterEach(func() {
+			readIDFromFile = origReadID
+		})
+
+		It("returns true for a new NVIDIA BDF created event", func() {
+			readIDFromFile = func(_, _, _ string) (string, error) { return nvidiaVendorID, nil }
+			ev := fsnotify.Event{Name: "/sys/.../0000:01:00.0", Op: fsnotify.Create}
+			Expect(isNewNvidiaBinding(ev, map[string]struct{}{})).To(BeTrue())
+		})
+
+		It("returns false for non-Create events", func() {
+			readIDFromFile = func(_, _, _ string) (string, error) { return nvidiaVendorID, nil }
+			ev := fsnotify.Event{Name: "/sys/.../0000:01:00.0", Op: fsnotify.Remove}
+			Expect(isNewNvidiaBinding(ev, map[string]struct{}{})).To(BeFalse())
+		})
+
+		It("returns false for sysfs control files", func() {
+			ev := fsnotify.Event{Name: "/sys/.../bind", Op: fsnotify.Create}
+			Expect(isNewNvidiaBinding(ev, map[string]struct{}{})).To(BeFalse())
+		})
+
+		It("returns false when the BDF is already in the baseline", func() {
+			readIDFromFile = func(_, _, _ string) (string, error) { return nvidiaVendorID, nil }
+			ev := fsnotify.Event{Name: "/sys/.../0000:01:00.0", Op: fsnotify.Create}
+			baseline := map[string]struct{}{"0000:01:00.0": {}}
+			Expect(isNewNvidiaBinding(ev, baseline)).To(BeFalse())
+		})
+
+		It("returns false for non-NVIDIA vendor", func() {
+			readIDFromFile = func(_, _, _ string) (string, error) { return "8086", nil }
+			ev := fsnotify.Event{Name: "/sys/.../0000:01:00.0", Op: fsnotify.Create}
+			Expect(isNewNvidiaBinding(ev, map[string]struct{}{})).To(BeFalse())
+		})
+
+		It("returns false when vendor read fails", func() {
+			readIDFromFile = func(_, _, _ string) (string, error) { return "", os.ErrNotExist }
+			ev := fsnotify.Event{Name: "/sys/.../0000:01:00.0", Op: fsnotify.Create}
+			Expect(isNewNvidiaBinding(ev, map[string]struct{}{})).To(BeFalse())
+		})
+	})
+
+	Describe("watchVfioBindings", func() {
+		var (
+			tmpDir              string
+			origDriversBasePath string
+			origNvidiaVfioBdfs  func() map[string]struct{}
+			origReadID          func(string, string, string) (string, error)
+		)
+
+		BeforeEach(func() {
+			var err error
+			tmpDir, err = os.MkdirTemp("", "vfio-watcher-test")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.MkdirAll(filepath.Join(tmpDir, "vfio-pci"), 0o755)).To(Succeed())
+
+			origDriversBasePath = pciDriversBasePath
+			origNvidiaVfioBdfs = nvidiaVfioBdfs
+			origReadID = readIDFromFile
+			pciDriversBasePath = tmpDir
+		})
+
+		AfterEach(func() {
+			pciDriversBasePath = origDriversBasePath
+			nvidiaVfioBdfs = origNvidiaVfioBdfs
+			readIDFromFile = origReadID
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
+
+		It("closes stop when a new NVIDIA BDF appears after startup", func() {
+			// Baseline captured as empty; new BDF will be created after the
+			// goroutine starts.
+			nvidiaVfioBdfs = func() map[string]struct{} { return map[string]struct{}{} }
+			readIDFromFile = func(_, _, _ string) (string, error) { return nvidiaVendorID, nil }
+
+			stop := make(chan struct{})
+			go watchVfioBindings(stop)
+
+			// Give the watcher a moment to set up its fsnotify Add.
+			time.Sleep(150 * time.Millisecond)
+
+			// Simulate a binding by creating a BDF entry in the watched dir.
+			Expect(os.WriteFile(filepath.Join(tmpDir, "vfio-pci", "0000:01:00.0"), nil, 0o644)).To(Succeed())
+
+			Eventually(stop, "2s").Should(BeClosed())
+		})
+
+		It("closes stop on the post-baseline rescan when a binding races in", func() {
+			// First call (baseline) returns empty; second call (post-Add
+			// rescan) returns a new BDF — simulating vfio-manager binding
+			// during the small window between the two reads.
+			calls := 0
+			nvidiaVfioBdfs = func() map[string]struct{} {
+				calls++
+				if calls == 1 {
+					return map[string]struct{}{}
+				}
+				return map[string]struct{}{"0000:01:00.0": {}}
+			}
+
+			stop := make(chan struct{})
+			go watchVfioBindings(stop)
+
+			Eventually(stop, "2s").Should(BeClosed())
+		})
+
+		It("ignores Create events for sysfs control entries", func() {
+			nvidiaVfioBdfs = func() map[string]struct{} { return map[string]struct{}{} }
+			readIDFromFile = func(_, _, _ string) (string, error) { return nvidiaVendorID, nil }
+
+			stop := make(chan struct{})
+			go watchVfioBindings(stop)
+			time.Sleep(150 * time.Millisecond)
+
+			Expect(os.WriteFile(filepath.Join(tmpDir, "vfio-pci", "bind"), nil, 0o644)).To(Succeed())
+
+			Consistently(stop, "300ms").ShouldNot(BeClosed())
+			close(stop) // unblock the goroutine
+		})
+
+		It("ignores Create events for non-NVIDIA vendor devices", func() {
+			nvidiaVfioBdfs = func() map[string]struct{} { return map[string]struct{}{} }
+			readIDFromFile = func(_, _, _ string) (string, error) { return "8086", nil }
+
+			stop := make(chan struct{})
+			go watchVfioBindings(stop)
+			time.Sleep(150 * time.Millisecond)
+
+			Expect(os.WriteFile(filepath.Join(tmpDir, "vfio-pci", "0000:01:00.0"), nil, 0o644)).To(Succeed())
+
+			Consistently(stop, "300ms").ShouldNot(BeClosed())
+			close(stop)
+		})
+
+		It("exits cleanly when no supported VFIO driver dirs exist", func() {
+			Expect(os.RemoveAll(filepath.Join(tmpDir, "vfio-pci"))).To(Succeed())
+			nvidiaVfioBdfs = func() map[string]struct{} { return map[string]struct{}{} }
+
+			stop := make(chan struct{})
+			done := make(chan struct{})
+			go func() {
+				watchVfioBindings(stop)
+				close(done)
+			}()
+
+			Eventually(done, "1s").Should(BeClosed())
+			Expect(stop).NotTo(BeClosed())
+		})
+	})
+})

--- a/pkg/device_plugin/vfio_watcher_test.go
+++ b/pkg/device_plugin/vfio_watcher_test.go
@@ -184,14 +184,18 @@ var _ = Describe("vfio-watcher", func() {
 			nvidiaVfioBdfs = func() map[string]struct{} { return map[string]struct{}{} }
 			readIDFromFile = func(_, _, _ string) (string, error) { return nvidiaVendorID, nil }
 
-			origCb := onNewVfioBdf
-			defer func() { onNewVfioBdf = origCb }()
 			seen := make(chan string, 4)
-			onNewVfioBdf = func(bdf string) { seen <- bdf }
-
 			stop := make(chan struct{})
-			defer close(stop)
-			go watchVfioBindings(stop)
+			done := make(chan struct{})
+			go func() {
+				watchVfioBindings(stop, func(bdf string) { seen <- bdf })
+				close(done)
+			}()
+			defer func() {
+				close(stop)
+				Eventually(done, "2s").Should(BeClosed(),
+					"watcher goroutine must exit before the next test mutates package globals")
+			}()
 
 			// Give the watcher a moment to set up its fsnotify Add.
 			time.Sleep(150 * time.Millisecond)
@@ -216,14 +220,18 @@ var _ = Describe("vfio-watcher", func() {
 				return map[string]struct{}{"0000:01:00.0": {}}
 			}
 
-			origCb := onNewVfioBdf
-			defer func() { onNewVfioBdf = origCb }()
 			seen := make(chan string, 4)
-			onNewVfioBdf = func(bdf string) { seen <- bdf }
-
 			stop := make(chan struct{})
-			defer close(stop)
-			go watchVfioBindings(stop)
+			done := make(chan struct{})
+			go func() {
+				watchVfioBindings(stop, func(bdf string) { seen <- bdf })
+				close(done)
+			}()
+			defer func() {
+				close(stop)
+				Eventually(done, "2s").Should(BeClosed(),
+					"watcher goroutine must exit before the next test mutates package globals")
+			}()
 
 			Eventually(seen, "2s").Should(Receive(Equal("0000:01:00.0")),
 				"watcher must call onNewVfioBdf for BDFs that bound during the baseline-to-Add race window")
@@ -233,14 +241,18 @@ var _ = Describe("vfio-watcher", func() {
 			nvidiaVfioBdfs = func() map[string]struct{} { return map[string]struct{}{} }
 			readIDFromFile = func(_, _, _ string) (string, error) { return nvidiaVendorID, nil }
 
-			origCb := onNewVfioBdf
-			defer func() { onNewVfioBdf = origCb }()
 			seen := make(chan string, 4)
-			onNewVfioBdf = func(bdf string) { seen <- bdf }
-
 			stop := make(chan struct{})
-			defer close(stop)
-			go watchVfioBindings(stop)
+			done := make(chan struct{})
+			go func() {
+				watchVfioBindings(stop, func(bdf string) { seen <- bdf })
+				close(done)
+			}()
+			defer func() {
+				close(stop)
+				Eventually(done, "2s").Should(BeClosed(),
+					"watcher goroutine must exit before the next test mutates package globals")
+			}()
 			time.Sleep(150 * time.Millisecond)
 
 			Expect(os.WriteFile(filepath.Join(tmpDir, "vfio-pci", "bind"), nil, 0o644)).To(Succeed())
@@ -252,14 +264,18 @@ var _ = Describe("vfio-watcher", func() {
 			nvidiaVfioBdfs = func() map[string]struct{} { return map[string]struct{}{} }
 			readIDFromFile = func(_, _, _ string) (string, error) { return "8086", nil }
 
-			origCb := onNewVfioBdf
-			defer func() { onNewVfioBdf = origCb }()
 			seen := make(chan string, 4)
-			onNewVfioBdf = func(bdf string) { seen <- bdf }
-
 			stop := make(chan struct{})
-			defer close(stop)
-			go watchVfioBindings(stop)
+			done := make(chan struct{})
+			go func() {
+				watchVfioBindings(stop, func(bdf string) { seen <- bdf })
+				close(done)
+			}()
+			defer func() {
+				close(stop)
+				Eventually(done, "2s").Should(BeClosed(),
+					"watcher goroutine must exit before the next test mutates package globals")
+			}()
 			time.Sleep(150 * time.Millisecond)
 
 			Expect(os.WriteFile(filepath.Join(tmpDir, "vfio-pci", "0000:01:00.0"), nil, 0o644)).To(Succeed())
@@ -274,7 +290,7 @@ var _ = Describe("vfio-watcher", func() {
 			stop := make(chan struct{})
 			done := make(chan struct{})
 			go func() {
-				watchVfioBindings(stop)
+				watchVfioBindings(stop, func(string) {})
 				close(done)
 			}()
 

--- a/pkg/device_plugin/vfio_watcher_test.go
+++ b/pkg/device_plugin/vfio_watcher_test.go
@@ -178,13 +178,19 @@ var _ = Describe("vfio-watcher", func() {
 			Expect(os.RemoveAll(tmpDir)).To(Succeed())
 		})
 
-		It("closes stop when a new NVIDIA BDF appears after startup", func() {
+		It("invokes the callback when a new NVIDIA BDF appears after startup", func() {
 			// Baseline captured as empty; new BDF will be created after the
 			// goroutine starts.
 			nvidiaVfioBdfs = func() map[string]struct{} { return map[string]struct{}{} }
 			readIDFromFile = func(_, _, _ string) (string, error) { return nvidiaVendorID, nil }
 
+			origCb := onNewVfioBdf
+			defer func() { onNewVfioBdf = origCb }()
+			seen := make(chan string, 4)
+			onNewVfioBdf = func(bdf string) { seen <- bdf }
+
 			stop := make(chan struct{})
+			defer close(stop)
 			go watchVfioBindings(stop)
 
 			// Give the watcher a moment to set up its fsnotify Add.
@@ -193,10 +199,11 @@ var _ = Describe("vfio-watcher", func() {
 			// Simulate a binding by creating a BDF entry in the watched dir.
 			Expect(os.WriteFile(filepath.Join(tmpDir, "vfio-pci", "0000:01:00.0"), nil, 0o644)).To(Succeed())
 
-			Eventually(stop, "2s").Should(BeClosed())
+			Eventually(seen, "2s").Should(Receive(Equal("0000:01:00.0")),
+				"watcher must call onNewVfioBdf so the plugin can incrementally publish the new GPU — without exiting the process")
 		})
 
-		It("closes stop on the post-baseline rescan when a binding races in", func() {
+		It("invokes the callback on the post-baseline rescan when a binding races in", func() {
 			// First call (baseline) returns empty; second call (post-Add
 			// rescan) returns a new BDF — simulating vfio-manager binding
 			// during the small window between the two reads.
@@ -209,38 +216,55 @@ var _ = Describe("vfio-watcher", func() {
 				return map[string]struct{}{"0000:01:00.0": {}}
 			}
 
+			origCb := onNewVfioBdf
+			defer func() { onNewVfioBdf = origCb }()
+			seen := make(chan string, 4)
+			onNewVfioBdf = func(bdf string) { seen <- bdf }
+
 			stop := make(chan struct{})
+			defer close(stop)
 			go watchVfioBindings(stop)
 
-			Eventually(stop, "2s").Should(BeClosed())
+			Eventually(seen, "2s").Should(Receive(Equal("0000:01:00.0")),
+				"watcher must call onNewVfioBdf for BDFs that bound during the baseline-to-Add race window")
 		})
 
 		It("ignores Create events for sysfs control entries", func() {
 			nvidiaVfioBdfs = func() map[string]struct{} { return map[string]struct{}{} }
 			readIDFromFile = func(_, _, _ string) (string, error) { return nvidiaVendorID, nil }
 
+			origCb := onNewVfioBdf
+			defer func() { onNewVfioBdf = origCb }()
+			seen := make(chan string, 4)
+			onNewVfioBdf = func(bdf string) { seen <- bdf }
+
 			stop := make(chan struct{})
+			defer close(stop)
 			go watchVfioBindings(stop)
 			time.Sleep(150 * time.Millisecond)
 
 			Expect(os.WriteFile(filepath.Join(tmpDir, "vfio-pci", "bind"), nil, 0o644)).To(Succeed())
 
-			Consistently(stop, "300ms").ShouldNot(BeClosed())
-			close(stop) // unblock the goroutine
+			Consistently(seen, "300ms").ShouldNot(Receive())
 		})
 
 		It("ignores Create events for non-NVIDIA vendor devices", func() {
 			nvidiaVfioBdfs = func() map[string]struct{} { return map[string]struct{}{} }
 			readIDFromFile = func(_, _, _ string) (string, error) { return "8086", nil }
 
+			origCb := onNewVfioBdf
+			defer func() { onNewVfioBdf = origCb }()
+			seen := make(chan string, 4)
+			onNewVfioBdf = func(bdf string) { seen <- bdf }
+
 			stop := make(chan struct{})
+			defer close(stop)
 			go watchVfioBindings(stop)
 			time.Sleep(150 * time.Millisecond)
 
 			Expect(os.WriteFile(filepath.Join(tmpDir, "vfio-pci", "0000:01:00.0"), nil, 0o644)).To(Succeed())
 
-			Consistently(stop, "300ms").ShouldNot(BeClosed())
-			close(stop)
+			Consistently(seen, "300ms").ShouldNot(Receive())
 		})
 
 		It("exits cleanly when no supported VFIO driver dirs exist", func() {


### PR DESCRIPTION
## Summary

Move the busy-vfio detection from discovery to the allocation path so node `nvidia.com/<model>` capacity reflects physical hardware while still preventing the EBUSY crashloop.

## Why

The previous fork build (master @ 74d7383d / images `81996523` & `74d7383d`) marks PCI devices whose `/dev/vfio/<group>` is held by another process as **Unhealthy at discovery**. That keeps kubelet from handing the same ID to a new pod, but it also shrinks `allocatable` from physical capacity (8) to free count (2).

Hive's platform-api computes:

```
available = allocatable − sum(GPUs of running instances)
```

So on an 8x-GPU node with 3 tenants holding 6 GPUs the location went from `8 − 6 = 2` (could schedule) to `2 − 6 = −4` (location reports negative free GPUs → new instance creation rejected up front).

This rolled out at 13:21 UTC today and immediately blocked the customer who'd just lost their VM to the original crashloop; the location showed "no GPUs available" even though 2 were physically free on cptcor01.

## Change

- **`device_plugin.go`**: every vfio-pci-bound GPU is now registered as `Healthy`. Node capacity equals the physical hardware again.
- **`vfio_busy.go`**: new `substituteBusyDevices()` swaps any requested PCI ID whose IOMMU group is currently held with a free device from the same pool. New `filterPreferredFreeDevices()` biases `GetPreferredAllocation()` so kubelet's NUMA pass picks free devices first.
- **`generic_device_plugin.go`**: `Allocate()` preprocesses `req.DevicesIDs` with `substituteBusyDevices` and uses the swapped list for both the per-device spec loop and the EGM path lookup. `GetPreferredAllocation()` reorders `AvailableDeviceIDs` to prefer free devices.

If every candidate in the pool is busy, `Allocate()` returns an error so kubelet retries rather than producing a guaranteed-EBUSY allocation.

## Test plan
- [x] Unit tests cover no-busy, single-swap, two-pass (free-request-after-busy-request), exhausted-pool, and preferred-allocation reordering. `go test ./...` → 81/81 pass.
- [ ] After image build + rollout: `kubectl describe node cptcor01 | grep GB202` reports allocatable=8 (was 2)
- [ ] `kpt location_status hivenet-cor` shows `available_gpu: 2` (was -4)
- [ ] Customer can create a 2× RTX 5090 VM on hivenet-cor and it reaches Running
- [ ] Peer VMs on cptcor01 stay Running through the rollout
- [ ] Any later allocation that would have hit a busy PCI ID is silently swapped, visible in plugin logs as `Allocate: substituted busy devices [old] -> [new]`

## Related
- [COMP-2335](https://antimatterhq.atlassian.net/browse/COMP-2335) (Done) — earlier fork-side fix that introduced the over-correction.
- [COMP-2336](https://antimatterhq.atlassian.net/browse/COMP-2336) — staging variant of the original crashloop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)