### PR TITLE
fix: remove legacy registry API  docker manifest create

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -126,8 +126,7 @@ jobs:
         env:
           MULTIARCH_IMAGE: ghcr.io/${{ env.LOWERCASE_REPO_OWNER }}/kubevirt-gpu-device-plugin:${{ env.COMMIT_SHORT_SHA }}
         run: |
-          docker manifest create \
-            ${MULTIARCH_IMAGE} \
+          docker buildx imagetools create \
+            --tag ${MULTIARCH_IMAGE} \
             ghcr.io/${{ env.LOWERCASE_REPO_OWNER }}/kubevirt-gpu-device-plugin:${{ env.COMMIT_SHORT_SHA }}-amd64 \
             ghcr.io/${{ env.LOWERCASE_REPO_OWNER }}/kubevirt-gpu-device-plugin:${{ env.COMMIT_SHORT_SHA }}-arm64
-          docker manifest push ${MULTIARCH_IMAGE}


### PR DESCRIPTION
`docker manifest create/push ` uses the legacy registry API which pushes platform manifests individually, leaving them resolvable directly.  `nvcr.io` then resolves the tag to the amd64 platform manifest instead of the manifest list. 

`docker buildx imagetools create` uses the modern OCI API and creates a proper Docker manifest list where only the top-level digest is resolvable. 