### PR TITLE
Allocate: expose only the requested device's address per resource

### DIFF
--- a/pkg/device_plugin/generic_device_plugin.go
+++ b/pkg/device_plugin/generic_device_plugin.go
@@ -396,7 +396,6 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 					return nil, fmt.Errorf("invalid allocation request: unknown device: %s", dev.addr)
 				}
 
-				devAddrs = append(devAddrs, dev.addr)
 				if dev.addr == bdf {
 					requestedDeviceFound = true
 				}
@@ -411,6 +410,14 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 			if !requestedDeviceFound {
 				return nil, fmt.Errorf("invalid allocation request: unknown device: %s", bdf)
 			}
+			// Expose only the requested device's address in this resource's env.
+			// KubeVirt assigns these addresses positionally to the consuming
+			// slots, so advertising the other functions of the IOMMU group lets a
+			// sibling occupy a slot meant for another requested device. The full
+			// group is still bound via the vfio DeviceSpecs below, and each
+			// function is its own resource, so a sibling can be requested directly.
+			devAddrs = append(devAddrs, bdf)
+
 			appendDeviceSpec(&deviceSpecs, seenDeviceSpecs, filepath.Join(vfioDevicePath, "vfio"))
 			appendDeviceSpec(&deviceSpecs, seenDeviceSpecs, filepath.Join(vfioDevicePath, iommuId))
 			if iommufdSupported {

--- a/pkg/device_plugin/generic_device_plugin_test.go
+++ b/pkg/device_plugin/generic_device_plugin_test.go
@@ -270,6 +270,34 @@ var _ = Describe("Generic Device", func() {
 		}
 	})
 
+	It("Should expose only the requested function, not its IOMMU-group siblings", func() {
+		// A multi-function card: one IOMMU group holds a GPU plus its HD-audio
+		// sibling. When the GPU is requested, only the GPU address must land in
+		// PCI_RESOURCE_NVIDIA_COM_* — not the audio sibling — so KubeVirt does
+		// not map the sibling into another `gpus:` slot (which would displace a
+		// real second GPU). The audio is reachable via its own resource.
+		gpuAddr, audioAddr, grp := "g0", "g1", "9"
+		returnIommuMap = func() map[string][]NvidiaGpuDevice {
+			return map[string][]NvidiaGpuDevice{grp: {{addr: gpuAddr}, {addr: audioAddr}}}
+		}
+		returnBdfToIommuMap = func() map[string]string {
+			return map[string]string{gpuAddr: grp, audioAddr: grp}
+		}
+		readLink = func(basePath, deviceAddress, link string) (string, error) { return grp, nil }
+		readIDFromFile = func(basePath, deviceAddress, link string) (string, error) {
+			return nvVendorID, nil // both functions are NVIDIA (10de)
+		}
+
+		envKey := gpuPrefix + "_FOO"
+		requests := pluginapi.AllocateRequest{}
+		requests.ContainerRequests = append(requests.ContainerRequests,
+			&pluginapi.ContainerAllocateRequest{DevicesIDs: []string{gpuAddr}})
+		responses, err := dpi.Allocate(context.Background(), &requests)
+		Expect(err).To(BeNil())
+		// Only the requested GPU function is exposed; the audio sibling is NOT.
+		Expect(responses.GetContainerResponses()[0].Envs[envKey]).To(Equal(gpuAddr))
+	})
+
 	It("Should allocate a device without error with iommufd support", func() {
 		Expect(os.MkdirAll(filepath.Join(workDir, "dev"), 0744)).To(Succeed())
 		f, err := os.OpenFile(filepath.Join(workDir, "dev", "iommu"), os.O_RDONLY|os.O_CREATE, 0666)


### PR DESCRIPTION
## Problem

`Allocate` adds every function of a device's IOMMU group to the requested
resource's `PCI_RESOURCE_*` env. KubeVirt consumes those addresses
positionally, mapping them to the `gpus:` / `hostDevices:` slots in request
order. For a multi-function device this hands a sibling function (e.g. a
GPU's audio function) an address slot of its own — so when a VM requests two
of the same resource, the first device's sibling fills the second slot and
the guest sees only one device instead of two.

## Fix

Expose only the requested device's address in its resource env. The full
IOMMU group is still bound via the vfio `DeviceSpecs`, and each function is
already advertised as its own resource, so a workload that needs a sibling
function requests it explicitly via `hostDevices:`. The change is symmetric
across resources and keeps non-display functions available.

Adds a unit test covering a multi-function IOMMU group.

## Validation

Validated on a 2-GPU passthrough VM (KubeVirt v1.5.x): before the change the
guest saw a single GPU; after it sees both. Single-GPU and audio-passthrough
cases are unaffected; `go test ./pkg/device_plugin/` passes.
