### PR TITLE
fix: scope Allocate env map to each container request

### DIFF
--- a/pkg/device_plugin/generic_device_plugin.go
+++ b/pkg/device_plugin/generic_device_plugin.go
@@ -359,7 +359,6 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 	log.Printf("[%s] This means kubelet passed Topology Manager admission!", dpi.deviceName)
 
 	responses := pluginapi.AllocateResponse{}
-	envList := map[string][]string{}
 	iommufdSupported, err := supportsIOMMUFD()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine iommufd support: %w", err)
@@ -372,6 +371,9 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 	for _, req := range reqs.ContainerRequests {
 		deviceSpecs := make([]*pluginapi.DeviceSpec, 0)
 		seenDeviceSpecs := make(map[string]struct{})
+		// Scoped to the container: a response must advertise only the devices
+		// requested for its own container.
+		envList := map[string][]string{}
 		returnedMap := returnIommuMap()
 		bdfToIommu := returnBdfToIommuMap()
 		for _, bdf := range req.DevicesIds {

--- a/pkg/device_plugin/generic_device_plugin.go
+++ b/pkg/device_plugin/generic_device_plugin.go
@@ -358,7 +358,6 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 	log.Printf("[%s] This means kubelet passed Topology Manager admission!", dpi.deviceName)
 
 	responses := pluginapi.AllocateResponse{}
-	envList := map[string][]string{}
 	iommufdSupported, err := supportsIOMMUFD()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine iommufd support: %w", err)
@@ -371,6 +370,9 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 	for _, req := range reqs.ContainerRequests {
 		deviceSpecs := make([]*pluginapi.DeviceSpec, 0)
 		seenDeviceSpecs := make(map[string]struct{})
+		// Scoped to the container: a response must advertise only the devices
+		// requested for its own container.
+		envList := map[string][]string{}
 		returnedMap := returnIommuMap()
 		bdfToIommu := returnBdfToIommuMap()
 		for _, bdf := range req.DevicesIDs {

--- a/pkg/device_plugin/generic_device_plugin_test.go
+++ b/pkg/device_plugin/generic_device_plugin_test.go
@@ -298,6 +298,39 @@ var _ = Describe("Generic Device", func() {
 		Expect(responses.GetContainerResponses()[0].Envs[envKey]).To(Equal(gpuAddr))
 	})
 
+	It("Should not expose one container's devices to another container in the same request", func() {
+		// AllocateRequest.ContainerRequests is a repeated field. Each response
+		// must describe only the devices requested in its own entry; state
+		// carried across the loop would name hardware from a different entry.
+		readIDFromFile = func(basePath, deviceAddress, link string) (string, error) {
+			return nvVendorID, nil // both requested addresses are NVIDIA (10de)
+		}
+		envKey := gpuPrefix + "_FOO"
+		requests := pluginapi.AllocateRequest{}
+		requests.ContainerRequests = append(requests.ContainerRequests,
+			&pluginapi.ContainerAllocateRequest{DevicesIds: []string{pciAddress1}},
+			&pluginapi.ContainerAllocateRequest{DevicesIds: []string{pciAddress2}})
+		responses, err := dpi.Allocate(context.Background(), &requests)
+		Expect(err).To(BeNil())
+		Expect(responses.GetContainerResponses()).To(HaveLen(2))
+		Expect(responses.GetContainerResponses()[0].Envs[envKey]).To(Equal(pciAddress1))
+		Expect(responses.GetContainerResponses()[1].Envs[envKey]).To(Equal(pciAddress2))
+
+		// The device nodes must be isolated per entry too, so that hoisting any
+		// other per-container state out of the loop is caught here as well.
+		hostPaths := func(specs []*pluginapi.DeviceSpec) []string {
+			paths := []string{}
+			for _, spec := range specs {
+				paths = append(paths, spec.HostPath)
+			}
+			return paths
+		}
+		Expect(hostPaths(responses.GetContainerResponses()[0].Devices)).To(
+			And(ContainElement("/dev/vfio/"+iommuGroup1), Not(ContainElement("/dev/vfio/"+iommuGroup2))))
+		Expect(hostPaths(responses.GetContainerResponses()[1].Devices)).To(
+			And(ContainElement("/dev/vfio/"+iommuGroup2), Not(ContainElement("/dev/vfio/"+iommuGroup1))))
+	})
+
 	It("Should allocate a device without error with iommufd support", func() {
 		Expect(os.MkdirAll(filepath.Join(workDir, "dev"), 0744)).To(Succeed())
 		f, err := os.OpenFile(filepath.Join(workDir, "dev", "iommu"), os.O_RDONLY|os.O_CREATE, 0666)

--- a/pkg/device_plugin/generic_device_plugin_test.go
+++ b/pkg/device_plugin/generic_device_plugin_test.go
@@ -298,6 +298,39 @@ var _ = Describe("Generic Device", func() {
 		Expect(responses.GetContainerResponses()[0].Envs[envKey]).To(Equal(gpuAddr))
 	})
 
+	It("Should not expose one container's devices to another container in the same request", func() {
+		// AllocateRequest.ContainerRequests is a repeated field. Each response
+		// must describe only the devices requested in its own entry; state
+		// carried across the loop would name hardware from a different entry.
+		readIDFromFile = func(basePath, deviceAddress, link string) (string, error) {
+			return nvVendorID, nil // both requested addresses are NVIDIA (10de)
+		}
+		envKey := gpuPrefix + "_FOO"
+		requests := pluginapi.AllocateRequest{}
+		requests.ContainerRequests = append(requests.ContainerRequests,
+			&pluginapi.ContainerAllocateRequest{DevicesIDs: []string{pciAddress1}},
+			&pluginapi.ContainerAllocateRequest{DevicesIDs: []string{pciAddress2}})
+		responses, err := dpi.Allocate(context.Background(), &requests)
+		Expect(err).To(BeNil())
+		Expect(responses.GetContainerResponses()).To(HaveLen(2))
+		Expect(responses.GetContainerResponses()[0].Envs[envKey]).To(Equal(pciAddress1))
+		Expect(responses.GetContainerResponses()[1].Envs[envKey]).To(Equal(pciAddress2))
+
+		// The device nodes must be isolated per entry too, so that hoisting any
+		// other per-container state out of the loop is caught here as well.
+		hostPaths := func(specs []*pluginapi.DeviceSpec) []string {
+			paths := []string{}
+			for _, spec := range specs {
+				paths = append(paths, spec.HostPath)
+			}
+			return paths
+		}
+		Expect(hostPaths(responses.GetContainerResponses()[0].Devices)).To(
+			And(ContainElement("/dev/vfio/"+iommuGroup1), Not(ContainElement("/dev/vfio/"+iommuGroup2))))
+		Expect(hostPaths(responses.GetContainerResponses()[1].Devices)).To(
+			And(ContainElement("/dev/vfio/"+iommuGroup2), Not(ContainElement("/dev/vfio/"+iommuGroup1))))
+	})
+
 	It("Should allocate a device without error with iommufd support", func() {
 		Expect(os.MkdirAll(filepath.Join(workDir, "dev"), 0744)).To(Succeed())
 		f, err := os.OpenFile(filepath.Join(workDir, "dev", "iommu"), os.O_RDONLY|os.O_CREATE, 0666)


### PR DESCRIPTION
`envList` was created once per `Allocate()` call and reused for every entry in `reqs.ContainerRequests`, so each entry's PCI addresses were appended to those of the entries processed before it. For requests naming devices `11` and `22`, the second response's `PCI_RESOURCE_NVIDIA_COM_*` is emitted as `11,22` — it names a device belonging to a different entry.

Moving the declaration inside the per-container loop scopes it correctly. `GenericVGpuDevicePlugin.Allocate()` already scopes its env map this way and is unaffected, so the generic plugin was the outlier. The declaration predates #191, which changed what enters `devAddrs` but not the scope of `envList`.

This is latent in practice: upstream kubelet sends a single `ContainerAllocateRequest` per call and reads only `ContainerResponses[0]`, so no released kubelet hits this path. The repeated field is part of the public device plugin API and nothing in its contract forbids batching, so the plugin should handle it correctly rather than depending on the caller sending one entry.

**Testing**

New spec in `generic_device_plugin_test.go` sends two container requests and asserts each response carries only its own device address and only its own `/dev/vfio/<group>` node. Verified it fails without the fix (entry 1 gets `11,22`) and passes with it; the device-node assertions additionally catch hoisting `deviceSpecs`/`seenDeviceSpecs` out of the loop. Full suite 43/43, no new `go vet` or `golangci-lint` findings against master.
