### PR TITLE
Add OCI standard image labels

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -83,7 +83,8 @@ jobs:
       - name: Build image
         env:
           IMAGE_NAME: ghcr.io/${LOWERCASE_REPO_OWNER}/kubevirt-gpu-device-plugin
-          VERSION: ${COMMIT_SHORT_SHA}-${{ matrix.arch }}
+          VERSION: ${COMMIT_SHORT_SHA}
+          IMAGE_TAG: ${COMMIT_SHORT_SHA}-${{ matrix.arch }}
           DOCKER_BUILD_PLATFORM_OPTIONS: "--platform=linux/${{ matrix.arch }}"
           GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url }}
         run: |

--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -63,6 +63,8 @@ RUN CGO_ENABLED=1 \
 FROM nvcr.io/nvidia/distroless/go:v4.1.1
 
 ARG VERSION
+ARG GIT_COMMIT
+ARG BUILD_TIMESTAMP
 
 LABEL io.k8s.display-name="NVIDIA KubeVirt GPU Device Plugin"
 LABEL name="NVIDIA KubeVirt GPU Device Plugin"
@@ -70,7 +72,17 @@ LABEL vendor="NVIDIA"
 LABEL version="${VERSION}"
 LABEL release="N/A"
 LABEL summary="NVIDIA device plugin for KubeVirt"
-LABEL description="See summary"
+LABEL description="NVIDIA device plugin for KubeVirt"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/distroless/go"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="NVIDIA device plugin for KubeVirt"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/kubevirt-gpu-device-plugin.git"
+LABEL org.opencontainers.image.title="NVIDIA KubeVirt GPU Device Plugin"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kubevirt-gpu-device-plugin"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${VERSION}"
 
 COPY --from=builder /workspace/nvidia-kubevirt-gpu-device-plugin /usr/bin/
 COPY --from=builder /workspace/utils/pci.ids /usr/pci.ids

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -27,7 +27,8 @@ GOPROXY ?= https://proxy.golang.org,direct
 
 IMAGE_VERSION := $(VERSION)
 
-IMAGE = $(IMAGE_NAME):$(IMAGE_VERSION)
+IMAGE_TAG ?= $(IMAGE_VERSION)
+IMAGE = $(IMAGE_NAME):$(IMAGE_TAG)
 
 OUT_IMAGE_NAME ?= $(IMAGE_NAME)
 OUT_IMAGE_VERSION ?= $(IMAGE_VERSION)
@@ -63,6 +64,7 @@ $(BUILD_TARGETS): build-%:
 		--build-arg VERSION="$(VERSION)" \
 		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
 		--build-arg GOPROXY="$(GOPROXY)" \
+		--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		--file $(DOCKERFILE) \
 		$(CURDIR)
 ifeq ($(PUSH_ON_BUILD),true)


### PR DESCRIPTION
This PR adds well-known OCI Image labels to the kubevirt-gpu-device-plugin image metadata.

**Before**
```
$ docker inspect --format='{{json .Config.Labels}}' nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0 | jq
{
  "description": "See summary",
  "io.k8s.display-name": "NVIDIA KubeVirt GPU Device Plugin",
  "name": "NVIDIA KubeVirt GPU Device Plugin",
  "org.opencontainers.image.created": "2026-02-19T22:52:35Z",
  "org.opencontainers.image.documentation": "https://gitlab-master.nvidia.com/gfn/security/container-hardening/distroless-sample-projects",
  "org.opencontainers.image.revision": "2455e95533eb544bf4a27f79cb14f82491752e06",
  "org.opencontainers.image.source": "https://gitlab-master.nvidia.com/gfn/security/container-hardening/baseimages",
  "org.opencontainers.image.title": "Golang Distroless Image",
  "org.opencontainers.image.url": "https://gitlab-master.nvidia.com/gfn/security/container-hardening/distroless-sample-projects",
  "org.opencontainers.image.version": "v4.0.2",
  "release": "N/A",
  "summary": "NVIDIA device plugin for KubeVirt",
  "vendor": "NVIDIA",
  "version": "b7968272-amd64"
}
```

**After** — built from this branch (fork PR CI does not publish images)
```
$ docker inspect --format='{{json .Config.Labels}}' nvcr.io/nvidia/kubevirt-gpu-device-plugin:76c2d281 | jq
{
  "description": "NVIDIA device plugin for KubeVirt",
  "io.k8s.display-name": "NVIDIA KubeVirt GPU Device Plugin",
  "name": "NVIDIA KubeVirt GPU Device Plugin",
  "org.opencontainers.image.base.name": "nvcr.io/nvidia/distroless/go",
  "org.opencontainers.image.created": "2026-08-17T18:41:58Z",
  "org.opencontainers.image.description": "NVIDIA device plugin for KubeVirt",
  "org.opencontainers.image.documentation": "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator",
  "org.opencontainers.image.revision": "76c2d2816faaded5ed17cd749c78219120910f57",
  "org.opencontainers.image.source": "https://github.com/NVIDIA/kubevirt-gpu-device-plugin.git",
  "org.opencontainers.image.title": "NVIDIA KubeVirt GPU Device Plugin",
  "org.opencontainers.image.url": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/kubevirt-gpu-device-plugin",
  "org.opencontainers.image.vendor": "NVIDIA",
  "org.opencontainers.image.version": "76c2d281",
  "release": "N/A",
  "summary": "NVIDIA device plugin for KubeVirt",
  "vendor": "NVIDIA",
  "version": "76c2d281"
}
```
