### PR TITLE
fuzz: improve GPU sysfs hex property parsing

### DIFF
--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -78,7 +78,7 @@ var supportedVfioDrivers = map[string]struct{}{
 }
 var pciIdsFilePath = "/usr/pci.ids"
 var readLink = readLinkFunc
-var readIDFromFile = readIDFromFileFunc
+var readHexIDFromFile = readHexIDFromFileFunc
 var readNUMANode = readNUMANodeFunc
 var startDevicePlugin = startDevicePluginFunc
 var readVgpuIDFromFile = readVgpuIDFromFileFunc
@@ -199,7 +199,7 @@ func createIommuDeviceMap() {
 			return nil
 		}
 		//Retrieve vendor for the device
-		vendorID, err := readIDFromFile(basePath, info.Name(), "vendor")
+		vendorID, err := readHexIDFromFile(basePath, info.Name(), "vendor")
 		if err != nil {
 			log.Println("Could not get vendor ID for device ", info.Name())
 			return nil
@@ -231,7 +231,7 @@ func createIommuDeviceMap() {
 			log.Println("Iommu Group " + iommuGroup)
 			// Always record this PCI device (BDF) under its device ID so we
 			// advertise actual PCI BDFs to kubelet and provide NUMA topology.
-			deviceID, err := readIDFromFile(basePath, info.Name(), "device")
+			deviceID, err := readHexIDFromFile(basePath, info.Name(), "device")
 			if err != nil {
 				log.Println("Could get deviceID for PCI address ", info.Name())
 				return nil
@@ -290,15 +290,29 @@ func createVgpuIDMap() {
 	})
 }
 
-// Read a file to retrieve ID
-func readIDFromFileFunc(basePath string, deviceAddress string, property string) (string, error) {
+// Read a file to retrieve hex property without leading prefix.
+func readHexIDFromFileFunc(basePath string, deviceAddress string, property string) (string, error) {
 	data, err := os.ReadFile(filepath.Join(basePath, deviceAddress, property))
 	if err != nil {
 		klog.Errorf("Could not read %s for device %s: %s", property, deviceAddress, err)
 		return "", err
 	}
-	id := strings.Trim(string(data[2:]), "\n")
-	return id, nil
+	id := strings.Trim(string(data), "\n")
+	// Value should have the hexadecimal prefix `0x`.
+	if !(strings.HasPrefix(strings.ToLower(id), "0x")) {
+		err := fmt.Errorf("value %q does not have a hexadecimal prefix", id)
+		klog.Errorf("Property %s (value: %q) for device %s is not a hex string", property, id, deviceAddress)
+		return "", err
+	}
+
+	// Parse as a hexadecimal number.
+	parsed, err := strconv.ParseUint(id[2:], 16, 64)
+	if err != nil {
+		klog.Errorf("Property %s (value: %q) for device %s is not a hex string: %s", property, id, deviceAddress, err)
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", parsed), nil
 }
 
 func readNUMANodeFunc(basePath string, deviceAddress string) (int64, error) {

--- a/pkg/device_plugin/device_plugin_test.go
+++ b/pkg/device_plugin/device_plugin_test.go
@@ -78,7 +78,7 @@ func getFakeLinkDevicePlugin(basePath string, deviceAddress string, link string)
 	return "", errors.New("Incorrect operation")
 }
 
-func getFakeIDFromFileDevicePlugin(basePath string, deviceAddress string, link string) (string, error) {
+func getFakeHexIDFromFileDevicePlugin(basePath string, deviceAddress string, link string) (string, error) {
 	if deviceAddress == deviceAddress1 || deviceAddress == deviceAddress4 || deviceAddress == deviceAddress5 {
 		if link == "vendor" {
 			return nvVendorID, nil
@@ -171,18 +171,35 @@ var _ = Describe("Device Plugin", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = os.Mkdir(workDir+"/1", 0755)
 			Expect(err).ToNot(HaveOccurred())
-			err = os.WriteFile(filepath.Join(workDir, deviceAddress1, "vendor"), []byte("0x10de"), 0644)
-			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Read driver with out error", func() {
-			driverID, err := readIDFromFileFunc(workDir, deviceAddress1, "vendor")
-			Expect(err).To(BeNil())
-			Expect(driverID).To(Equal(nvVendorID))
-		})
+		DescribeTable("parses hex property value in sysfs",
+			func(contents, expectedID string, expectError bool) {
+				err = os.WriteFile(filepath.Join(workDir, deviceAddress1, "vendor"), []byte(contents), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				id, err := readHexIDFromFileFunc(workDir, deviceAddress1, "vendor")
+				if expectError {
+					Expect(err).To(HaveOccurred())
+					Expect(id).To(BeEmpty())
+					return
+				}
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(id).To(Equal(expectedID))
+			},
+			Entry("reads a standard property value", "0x10de", nvVendorID, false),
+			Entry("trims a trailing newline", "0x1b80\n", "1b80", false),
+			Entry("normalizes uppercase hex and leading zeroes", "0X001B80\n", "1b80", false),
+			Entry("rejects a decimal value", "1234\n", "", true),
+			Entry("rejects input shorter than a hex prefix", "0", "", true),
+			Entry("rejects a prefix without digits", "0x", "", true),
+			Entry("rejects non-hex contents", "not-hex\n", "", true),
+			Entry("rejects an empty file", "", "", true),
+		)
 
 		It("Read driver from a missing location to throw error", func() {
-			driverID, err := readIDFromFileFunc(workDir, deviceAddress1, "iommu_group")
+			driverID, err := readHexIDFromFileFunc(workDir, deviceAddress1, "iommu_group")
 			Expect(err).ShouldNot(BeNil())
 			Expect(driverID).To(Equal(""))
 		})
@@ -303,7 +320,7 @@ var _ = Describe("Device Plugin", func() {
 
 		It("", func() {
 			readLink = getFakeLinkDevicePlugin
-			readIDFromFile = getFakeIDFromFileDevicePlugin
+			readHexIDFromFile = getFakeHexIDFromFileDevicePlugin
 			startDevicePlugin = fakeStartDevicePluginFunc
 			createIommuDeviceMap()
 

--- a/pkg/device_plugin/generic_device_plugin.go
+++ b/pkg/device_plugin/generic_device_plugin.go
@@ -391,7 +391,7 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 					log.Println("IommuGroup has changed on the system ", dev.addr)
 					return nil, fmt.Errorf("invalid allocation request: unknown device: %s", dev.addr)
 				}
-				vendorID, err := readIDFromFile(basePath, dev.addr, "vendor")
+				vendorID, err := readHexIDFromFile(basePath, dev.addr, "vendor")
 				if err != nil || vendorID != nvidiaVendorID {
 					log.Println("Vendor has changed on the system ", dev.addr)
 					return nil, fmt.Errorf("invalid allocation request: unknown device: %s", dev.addr)

--- a/pkg/device_plugin/generic_device_plugin_test.go
+++ b/pkg/device_plugin/generic_device_plugin_test.go
@@ -106,7 +106,7 @@ func getFakeLink(basePath string, deviceAddress string, link string) (string, er
 	}
 }
 
-func getFakeIDFromFile(basePath string, deviceAddress string, link string) (string, error) {
+func getFakeHexIDFromFile(basePath string, deviceAddress string, link string) (string, error) {
 	if deviceAddress == pciAddress1 {
 		return nvVendorID, nil
 	}
@@ -114,7 +114,7 @@ func getFakeIDFromFile(basePath string, deviceAddress string, link string) (stri
 
 }
 
-func getFakeIDFromFileForSharedEGM(basePath string, deviceAddress string, link string) (string, error) {
+func getFakeHexIDFromFileForSharedEGM(basePath string, deviceAddress string, link string) (string, error) {
 	if deviceAddress == pciAddress1 || deviceAddress == pciAddress2 {
 		return nvVendorID, nil
 	}
@@ -133,7 +133,7 @@ var _ = Describe("Generic Device", func() {
 		returnIommuMap = getFakeIommuMap
 		returnBdfToIommuMap = getFakeBdfToIommuMap
 		readLink = getFakeLink
-		readIDFromFile = getFakeIDFromFile
+		readHexIDFromFile = getFakeHexIDFromFile
 		discoverEGMDevices = getFakeEGMDevices
 		var devs []*pluginapi.Device
 		workDir, err = os.MkdirTemp("", "kubevirt-test")
@@ -196,7 +196,7 @@ var _ = Describe("Generic Device", func() {
 	})
 
 	It("Should inject EGM device when all associated GPUs are allocated", func() {
-		readIDFromFile = getFakeIDFromFileForSharedEGM
+		readHexIDFromFile = getFakeHexIDFromFileForSharedEGM
 		discoverEGMDevices = getFakeSharedEGMDevices
 		devs := []string{pciAddress1, pciAddress2}
 		envKey := gpuPrefix + "_FOO"
@@ -233,7 +233,7 @@ var _ = Describe("Generic Device", func() {
 	})
 
 	It("Should inject only the matching EGM device on a multi-socket system", func() {
-		readIDFromFile = getFakeIDFromFileForSharedEGM
+		readHexIDFromFile = getFakeHexIDFromFileForSharedEGM
 		discoverEGMDevices = getFakeMultiSocketEGMDevices
 		devs := []string{pciAddress1, pciAddress2}
 		containerRequests := pluginapi.ContainerAllocateRequest{DevicesIds: devs}
@@ -284,7 +284,7 @@ var _ = Describe("Generic Device", func() {
 			return map[string]string{gpuAddr: grp, audioAddr: grp}
 		}
 		readLink = func(basePath, deviceAddress, link string) (string, error) { return grp, nil }
-		readIDFromFile = func(basePath, deviceAddress, link string) (string, error) {
+		readHexIDFromFile = func(basePath, deviceAddress, link string) (string, error) {
 			return nvVendorID, nil // both functions are NVIDIA (10de)
 		}
 


### PR DESCRIPTION
Changes:
* Address plugin panic if the GPU sysfs property file being read is empty or less than 2 characters in size.
* Verify contents of the GPU sysfs property files are valid hexadecimal values.
